### PR TITLE
Removes some of the strange styling of Array.Extra

### DIFF
--- a/src/Array/Extra.elm
+++ b/src/Array/Extra.elm
@@ -236,13 +236,13 @@ and collect the result in a `List`.
             >> Html.div []
 
 -}
-indexedMapToList : (Int -> a -> b) -> (Array a -> List b)
-indexedMapToList mapIndexedElement array =
+indexedMapToList : (Int -> a -> b) -> Array a -> List b
+indexedMapToList fn array =
     array
         |> Array.foldr
             (\element ( i, listSoFar ) ->
                 ( i - 1
-                , mapIndexedElement i element :: listSoFar
+                , fn i element :: listSoFar
                 )
             )
             ( length array - 1, [] )
@@ -388,8 +388,8 @@ This is equivalent to `Array.filter (not << predicate)`.
 
 -}
 removeWhen : (a -> Bool) -> Array a -> Array a
-removeWhen isBad array =
-    Array.filter (\element -> not (isBad element)) array
+removeWhen shouldRemove array =
+    Array.filter (\element -> not (shouldRemove element)) array
 
 
 {-| Resize from the left, padding the right-hand side with a given value.
@@ -527,7 +527,7 @@ resizelIndexed lengthNew paddingElementForIndex array =
     --> empty
 
 -}
-resizerIndexed : Int -> (Int -> a) -> (Array a -> Array a)
+resizerIndexed : Int -> (Int -> a) -> Array a -> Array a
 resizerIndexed lengthNew paddingAtIndex array =
     let
         arrayLength =

--- a/src/Array/Extra.elm
+++ b/src/Array/Extra.elm
@@ -748,7 +748,7 @@ Extra elements of either `Array` are glued to the end without anything in betwee
     --> fromList [ "turtles", "on", "turtles", "turtles" ]
 
 -}
-interweave : Array element -> Array element -> Array element
+interweave : Array a -> Array a -> Array a
 interweave toInterweave array =
     let
         untilArrayEnd =


### PR DESCRIPTION
@miniBill I think this addresses some of the issues you were expressing.

On a wider note, I despair of some of the functions in this module, as they don't seem very useful. We can check more methodically on https://segakcap.com/search?q=elm-community/array-extra, but it seems like many of these aren't being used (at least in public code):

- `intersperse` basically just a wrapper around `List.intersperse`
- `pop` might be more useful if it returned the popped element
- `removeWhen` is just `filter` with `not`
- `unzip`, `zip2` and `zip3` are in my experience almost never used in Elm, as everyone just does their business with `map2`. At this point I'd much rather see `map2 Tuple.pair` than `zip2`.
- `apply` should probably just be a `andMap`
- `mapToList` and `indexedMapToList` I guess might be good for performance? I don't see them as amazing for code quality, as `Array.map fn |> Array.toList` seems much easier to understand.
- There are too many ways to resize an array.

On the other hand, it seems to be missing some fairly obvious and more useful array algorithms like bisection or selection.
