### PR TITLE
Fixed: Adjust underscored tests to match dasherize

### DIFF
--- a/tests/String/UnderscoredTest.elm
+++ b/tests/String/UnderscoredTest.elm
@@ -1,11 +1,11 @@
 module String.UnderscoredTest exposing (underscoredTest)
 
-import Char
+import Char.Extra
 import Expect
 import Fuzz exposing (..)
-import String exposing (replace)
+import Regex exposing (Regex)
+import String
 import String.Extra exposing (..)
-import String.TestData as TestData
 import Test exposing (..)
 
 
@@ -17,64 +17,29 @@ underscoredTest =
                 underscored s
                     |> String.toLower
                     |> Expect.equal (underscored s |> String.toLower)
-        , fuzz string "It replaces spaces and dashes with an underscore" <|
+        , fuzz string "It has no whitespace in the resulting string" <|
             \s ->
                 let
-                    expected =
-                        String.toLower
-                            >> String.trim
-                            >> replace "  " " "
-                            >> replace " " "-"
-                            >> replace "-" "_"
-                            >> replace "__" "_"
-                            >> replace "__" "_"
+                    whiteSpaceChecker =
+                        List.any Char.Extra.isSpace
                 in
                 underscored (String.toLower s)
-                    |> Expect.equal (expected s)
-        , fuzz TestData.randomStrings "It puts an underscore before each uppercase characters group unless it starts with uppercase" <|
+                    |> String.toList
+                    |> whiteSpaceChecker
+                    |> Expect.equal False
+        , fuzz string "It has no consecutive underscores in the resulting string" <|
             \s ->
-                underscored s
-                    |> Expect.equal (replaceUppercase s |> String.toLower)
+                let
+                    consecutiveUnderscoresChecker =
+                        Regex.contains consecutiveUnderscoresRegex
+                in
+                underscored (String.toLower s)
+                    |> consecutiveUnderscoresChecker
+                    |> Expect.equal False
         ]
 
 
-replaceUppercase : String -> String
-replaceUppercase string =
-    string
-        |> String.toList
-        |> List.indexedMap Tuple.pair
-        |> List.foldr recordUpperCasePositions []
-        |> List.foldl reduceList []
-        |> List.foldl replacePositions string
-
-
-recordUpperCasePositions : ( Int, Char ) -> List ( Int, Char ) -> List ( Int, Char )
-recordUpperCasePositions ( index, char ) acc =
-    if Char.isUpper char then
-        ( index, char ) :: acc
-
-    else
-        acc
-
-
-reduceList : ( Int, Char ) -> List ( Int, Int, Char ) -> List ( Int, Int, Char )
-reduceList ( index, char ) acc =
-    case acc of
-        ( start, end, c ) :: rest ->
-            if index == end + 1 then
-                ( start, index, c ) :: rest
-
-            else
-                ( index, index, char ) :: acc
-
-        [] ->
-            ( index, index, char ) :: acc
-
-
-replacePositions : ( Int, Int, Char ) -> String -> String
-replacePositions ( start, _, c ) string =
-    if start == 0 then
-        string
-
-    else
-        replaceSlice ("_" ++ String.fromChar c) start (start + 1) string
+consecutiveUnderscoresRegex : Regex
+consecutiveUnderscoresRegex =
+    Regex.fromString "_{2,}"
+        |> Maybe.withDefault Regex.never


### PR DESCRIPTION
The tests for underscored and dasherize were very similar, and dasherize relies on underscored to function.

So the tests for each of them were aligned. This also fixes a failure with the existing underscored test.