### PR TITLE
Fixed: Escape dash character

### DIFF
--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -337,7 +337,7 @@ underscored string =
     string
         |> String.trim
         |> Regex.replace (regexFromString "([a-z\\d])([A-Z]+)") (.submatches >> List.filterMap identity >> String.join "_")
-        |> Regex.replace (regexFromString "[_-\\s]+") (always "_")
+        |> Regex.replace (regexFromString "[_\\-\\s]+") (always "_")
         |> String.toLower
 
 


### PR DESCRIPTION
An unescaped dash can be misinterpreted in JavaScript, so it is escaped.

This is a follow-on from https://github.com/elm-community/string-extra/pull/47, but the method of fixing it is to explicitly escape the dash, rather than moving its position.