### PR TITLE
Causes elm-review to pass

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,11 +7,15 @@
     "exposed-modules": [
         "Array.Extra",
         "Basics.Extra",
+        "Char.Extra",
+        "Cmd.Extra",
         "Dict.Extra",
         "List.Extra",
         "Maybe.Extra",
+        "Order.Extra",
         "Result.Extra",
-        "String.Extra"
+        "String.Extra",
+        "Tuple.Extra"
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
@@ -19,6 +23,7 @@
         "elm/regex": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "2.0.0 <= v < 3.0.0"
+        "elm-explorations/test": "2.0.0 <= v < 3.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0"
     }
 }

--- a/review/suppressed/NoUnoptimizedRecursion.json
+++ b/review/suppressed/NoUnoptimizedRecursion.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "automatically created by": "elm-review suppress",
+  "learn more": "elm-review suppress --help",
+  "suppressions": [
+    { "count": 9, "filePath": "src/List/Extra.elm" }
+  ]
+}

--- a/src/List/Extra.elm
+++ b/src/List/Extra.elm
@@ -71,7 +71,7 @@ module List.Extra exposing
 
 -}
 
-import List exposing (..)
+import List
 import Tuple exposing (first, second)
 
 
@@ -316,7 +316,7 @@ maximumBy f ls =
             Just l_
 
         l_ :: ls_ ->
-            Just <| first <| foldl maxBy ( l_, f l_ ) ls_
+            Just <| first <| List.foldl maxBy ( l_, f l_ ) ls_
 
         _ ->
             Nothing
@@ -370,7 +370,7 @@ minimumBy f ls =
             Just l_
 
         l_ :: ls_ ->
-            Just <| first <| foldl minBy ( l_, f l_ ) ls_
+            Just <| first <| List.foldl minBy ( l_, f l_ ) ls_
 
         _ ->
             Nothing
@@ -522,7 +522,7 @@ uniqueHelp f existing remaining accumulator =
 -}
 andMap : List a -> List (a -> b) -> List b
 andMap l fl =
-    map2 (<|) fl l
+    List.map2 (<|) fl l
 
 
 {-| Equivalent to `concatMap`. For example, suppose you want to have a cartesian product of [1,2] and [3,4]:
@@ -554,7 +554,7 @@ Advanced functional programmers will recognize this as the implementation of bin
 -}
 andThen : (a -> List b) -> List a -> List b
 andThen =
-    concatMap
+    List.concatMap
 
 
 {-| `reverseMap f xs` gives the same result as `List.reverse (List.map f xs)`,
@@ -566,7 +566,7 @@ but is tail-recursive and slightly more efficient.
 -}
 reverseMap : (a -> b) -> List a -> List b
 reverseMap f xs =
-    foldl (\x acc -> f x :: acc) [] xs
+    List.foldl (\x acc -> f x :: acc) [] xs
 
 
 {-| `reverseMap f xs` gives the same result as `List.reverse (List.map f xs)`,
@@ -578,7 +578,7 @@ but is tail-recursive and slightly more efficient.
 -}
 reverseFilter : (a -> Bool) -> List a -> List a
 reverseFilter isGood xs =
-    foldl
+    List.foldl
         (\x acc ->
             if isGood x then
                 x :: acc
@@ -601,7 +601,7 @@ reverseFilter isGood xs =
 -}
 notMember : a -> List a -> Bool
 notMember x =
-    not << member x
+    not << List.member x
 
 
 {-| Find the first element that satisfies a predicate and return
@@ -975,12 +975,12 @@ removeAt index l =
         l
 
     else
-        case drop index l of
+        case List.drop index l of
             [] ->
                 l
 
             _ :: rest ->
-                take index l ++ rest
+                List.take index l ++ rest
 
 
 {-| Remove an element at an index that satisfies a predicate.
@@ -1028,7 +1028,7 @@ filterNot pred list =
 -}
 intercalate : List a -> List (List a) -> List a
 intercalate xs =
-    concat << intersperse xs
+    List.concat << List.intersperse xs
 
 
 {-| Transpose rows and columns of the list of lists.
@@ -1083,7 +1083,7 @@ subsequencesHelp list =
                 f ys r =
                     ys :: (first :: ys) :: r
             in
-            [ first ] :: foldr f [] (subsequencesHelp rest)
+            [ first ] :: List.foldr f [] (subsequencesHelp rest)
 
 
 {-| Return the list of all subsequences of the argument, except for the empty list.
@@ -1104,7 +1104,7 @@ subsequencesNonEmpty list =
                 f ( yf, ys ) r =
                     ( yf, ys ) :: ( first, yf :: ys ) :: r
             in
-            ( first, [] ) :: foldr f [] (subsequencesNonEmpty rest)
+            ( first, [] ) :: List.foldr f [] (subsequencesNonEmpty rest)
 
 
 {-| Return the list of of all permutations of a list. The result is in lexicographic order.
@@ -1122,9 +1122,9 @@ permutations xs_ =
         xs ->
             let
                 f ( y, ys ) =
-                    map ((::) y) (permutations ys)
+                    List.map ((::) y) (permutations ys)
             in
-            concatMap f (select xs)
+            List.concatMap f (select xs)
 
 
 {-| Return a list that contains elements from the two provided, in alternate order.
@@ -1337,7 +1337,7 @@ scanl f b xs =
 
         -- impossible
     in
-    reverse (foldl scan1 [ b ] xs)
+    List.reverse (List.foldl scan1 [ b ] xs)
 
 
 {-| `scanl1` is a variant of `scanl` that has no starting value argument.
@@ -1546,7 +1546,7 @@ unfoldr f seed =
 -}
 splitAt : Int -> List a -> ( List a, List a )
 splitAt n xs =
-    ( take n xs, drop n xs )
+    ( List.take n xs, List.drop n xs )
 
 
 {-| Attempts to split the list at the first element where the given predicate is true. If the predicate is not true for any elements in the list, return nothing. Otherwise, return the split list.
@@ -1580,7 +1580,7 @@ takeWhileRight p =
             else
                 ( xs, False )
     in
-    first << foldr step ( [], True )
+    first << List.foldr step ( [], True )
 
 
 {-| Drop elements from the right, while predicate still holds.
@@ -1591,9 +1591,9 @@ takeWhileRight p =
 -}
 dropWhileRight : (a -> Bool) -> List a -> List a
 dropWhileRight p =
-    foldr
+    List.foldr
         (\x xs ->
-            if p x && isEmpty xs then
+            if p x && List.isEmpty xs then
                 []
 
             else
@@ -1672,7 +1672,7 @@ stripPrefix prefix xs =
                     else
                         Nothing
     in
-    foldl step (Just xs) prefix
+    List.foldl step (Just xs) prefix
 
 
 {-| Group similar elements together. `group` is equivalent to `groupWhile (==)`.
@@ -1736,7 +1736,7 @@ groupWhile isSameGroup items =
 -}
 inits : List a -> List (List a)
 inits =
-    foldr (\e acc -> [] :: map ((::) e) acc) [ [] ]
+    List.foldr (\e acc -> [] :: List.map ((::) e) acc) [ [] ]
 
 
 {-| Return all final segments of a list, from longest to shortest, the list itself first, empty list last.
@@ -1747,7 +1747,7 @@ inits =
 -}
 tails : List a -> List (List a)
 tails =
-    foldr tailsHelp [ [] ]
+    List.foldr tailsHelp [ [] ]
 
 
 tailsHelp : a -> List (List a) -> List (List a)
@@ -1773,7 +1773,7 @@ select list =
             []
 
         x :: xs ->
-            ( x, xs ) :: map (\( y, ys ) -> ( y, x :: ys )) (select xs)
+            ( x, xs ) :: List.map (\( y, ys ) -> ( y, x :: ys )) (select xs)
 
 
 {-| Return all combinations in the form of (elements before, element, elements after).
@@ -1789,7 +1789,7 @@ selectSplit list =
             []
 
         x :: xs ->
-            ( [], x, xs ) :: map (\( lys, y, rys ) -> ( x :: lys, y, rys )) (selectSplit xs)
+            ( [], x, xs ) :: List.map (\( lys, y, rys ) -> ( x :: lys, y, rys )) (selectSplit xs)
 
 
 {-| Take two lists and return `True`, if the first list is the prefix of the second list.
@@ -1815,7 +1815,7 @@ isPrefixOf prefix list =
 -}
 isSuffixOf : List a -> List a -> Bool
 isSuffixOf suffix xs =
-    isPrefixOf (reverse suffix) (reverse xs)
+    isPrefixOf (List.reverse suffix) (List.reverse xs)
 
 
 {-| Return True if all the elements of the first list occur in-order and
@@ -1928,6 +1928,7 @@ removeOneMember culprit l =
     removeOneMemberHelp culprit [] l
 
 
+removeOneMemberHelp : a -> List a -> List a -> { foundAny : Bool, without : List a }
 removeOneMemberHelp culprit before list =
     case list of
         [] ->
@@ -1945,14 +1946,14 @@ removeOneMemberHelp culprit before list =
 -}
 zip : List a -> List b -> List ( a, b )
 zip =
-    map2 Tuple.pair
+    List.map2 Tuple.pair
 
 
 {-| Take three lists and returns a list of triples
 -}
 zip3 : List a -> List b -> List c -> List ( a, b, c )
 zip3 =
-    map3 triple
+    List.map3 triple
 
 
 triple : a -> b -> c -> ( a, b, c )
@@ -1972,13 +1973,15 @@ lift2 f la lb =
     la |> andThen (\a -> lb |> andThen (\b -> [ f a b ]))
 
 
-{-| -}
+{-| Maps a function over three lists, exploring all possible combinations.
+-}
 lift3 : (a -> b -> c -> d) -> List a -> List b -> List c -> List d
 lift3 f la lb lc =
     la |> andThen (\a -> lb |> andThen (\b -> lc |> andThen (\c -> [ f a b c ])))
 
 
-{-| -}
+{-| Maps a function over four lists, exploring all possible combinations.
+-}
 lift4 : (a -> b -> c -> d -> e) -> List a -> List b -> List c -> List d -> List e
 lift4 f la lb lc ld =
     la |> andThen (\a -> lb |> andThen (\b -> lc |> andThen (\c -> ld |> andThen (\d -> [ f a b c d ]))))

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -25,7 +25,7 @@ Work with 1 `Maybe`
 @docs withDefaultLazy, unwrap, unpack
 
 
-# Or
+# OR based logic
 
 Take the first value that's present
 
@@ -38,7 +38,7 @@ Take the first value that's present
 @docs combine, traverse, combineArray, traverseArray
 
 
-# toList
+# Transforming to collections
 
 @docs toList, toArray
 @docs cons
@@ -62,7 +62,7 @@ If you need a version of `andThenN` that takes more than 4 arguments, you can ch
 -}
 
 import Array
-import Maybe exposing (..)
+import Maybe
 
 
 
@@ -528,7 +528,7 @@ but works on [`Array`](https://package.elm-lang.org/packages/elm/core/latest/Arr
 -}
 combineArray : Array.Array (Maybe a) -> Maybe (Array.Array a)
 combineArray =
-    Array.foldl (map2 Array.push) (Just Array.empty)
+    Array.foldl (Maybe.map2 Array.push) (Just Array.empty)
 
 
 {-| Like [`traverse`](#traverse),
@@ -536,7 +536,7 @@ but works on [`Array`](https://package.elm-lang.org/packages/elm/core/latest/Arr
 -}
 traverseArray : (a -> Maybe b) -> Array.Array a -> Maybe (Array.Array b)
 traverseArray f =
-    Array.foldl (\x -> map2 Array.push (f x)) (Just Array.empty)
+    Array.foldl (\x -> Maybe.map2 Array.push (f x)) (Just Array.empty)
 
 
 
@@ -643,7 +643,8 @@ andThen2 func ma mb =
             Nothing
 
 
-{-| -}
+{-| `andThen` for 3 maybes.
+-}
 andThen3 : (a -> b -> c -> Maybe value) -> Maybe a -> Maybe b -> Maybe c -> Maybe value
 andThen3 func ma mb mc =
     case ma of
@@ -664,7 +665,8 @@ andThen3 func ma mb mc =
             Nothing
 
 
-{-| -}
+{-| `andThen` for 4 maybes.
+-}
 andThen4 : (a -> b -> c -> d -> Maybe value) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe value
 andThen4 func ma mb mc md =
     case ma of
@@ -709,7 +711,7 @@ If either argument is `Nothing`, return `Nothing`.
         |> andMap Nothing
     --> Nothing
 
-This can be used to do [`Maybe.mapN`](https://package.elm-lang.org/packages/elm/core/latest/Maybe#map2) or [`andThenN`](#andThenN) for any number of arguments.
+This can be used to do [`Maybe.mapN`](https://package.elm-lang.org/packages/elm/core/latest/Maybe#map2) or [`andThenN`](#andthenn) for any number of arguments.
 
     -- map4
     Just (\a b c d -> a + b + c + d )

--- a/src/String/Normalize.elm
+++ b/src/String/Normalize.elm
@@ -149,7 +149,7 @@ cleanupPath keepChars str =
 
 
 cleanup : Set Char -> Char -> String -> String
-cleanup keepChars separator str =
+cleanup keepChars _ str =
     let
         removePunctuation c =
             if Set.member c keepChars then

--- a/tests/ListTests.elm
+++ b/tests/ListTests.elm
@@ -2,7 +2,7 @@ module ListTests exposing (all)
 
 import Expect
 import Fuzz
-import List.Extra exposing (..)
+import List.Extra exposing (Step(..))
 import Test exposing (Test, describe, fuzz, fuzz2, fuzz3, test)
 
 
@@ -28,142 +28,142 @@ all =
                     Expect.equal
                         ([ 1, 2, 3 ]
                             |> List.map (\a b c -> a + b * c)
-                            |> andMap [ 4, 5, 6 ]
-                            |> andMap [ 2, 1, 1 ]
+                            |> List.Extra.andMap [ 4, 5, 6 ]
+                            |> List.Extra.andMap [ 2, 1, 1 ]
                         )
                         [ 9, 7, 9 ]
             ]
         , describe "reverseMap" <|
             [ test "maps and reverses" <|
                 \() ->
-                    Expect.equal (reverseMap sqrt [ 1, 4, 9 ]) [ 3, 2, 1 ]
+                    Expect.equal (List.Extra.reverseMap sqrt [ 1, 4, 9 ]) [ 3, 2, 1 ]
             ]
         , describe "reverseFilter" <|
             [ test "filters and reverses" <|
                 \() ->
-                    Expect.equal (reverseFilter (\x -> x > 5) [ 1, 4, 9, 16 ]) [ 16, 9 ]
+                    Expect.equal (List.Extra.reverseFilter (\x -> x > 5) [ 1, 4, 9, 16 ]) [ 16, 9 ]
             ]
         , describe "notMember" <|
             [ test "disconfirms member" <|
                 \() ->
-                    Expect.equal (notMember 1 [ 1, 2, 3 ]) False
+                    Expect.equal (List.Extra.notMember 1 [ 1, 2, 3 ]) False
             , test "confirms non-member" <|
                 \() ->
-                    Expect.equal (notMember 4 [ 1, 2, 3 ]) True
+                    Expect.equal (List.Extra.notMember 4 [ 1, 2, 3 ]) True
             ]
         , describe "find" <|
             [ test "behaves as documented" <|
                 \() ->
-                    Expect.equal (find (\num -> num > 5) [ 2, 4, 6, 8 ]) (Just 6)
+                    Expect.equal (List.Extra.find (\num -> num > 5) [ 2, 4, 6, 8 ]) (Just 6)
             ]
         , describe "elemIndex" <|
             [ test "finds index of value" <|
                 \() ->
-                    Expect.equal (elemIndex 1 [ 1, 2, 3 ]) (Just 0)
+                    Expect.equal (List.Extra.elemIndex 1 [ 1, 2, 3 ]) (Just 0)
             , test "doesn't find index of non-present" <|
                 \() ->
-                    Expect.equal (elemIndex 4 [ 1, 2, 3 ]) Nothing
+                    Expect.equal (List.Extra.elemIndex 4 [ 1, 2, 3 ]) Nothing
             , test "finds index of first match" <|
                 \() ->
-                    Expect.equal (elemIndex 1 [ 1, 2, 1 ]) (Just 0)
+                    Expect.equal (List.Extra.elemIndex 1 [ 1, 2, 1 ]) (Just 0)
             ]
         , describe "elemIndices" <|
             [ test "finds singleton index" <|
                 \() ->
-                    Expect.equal (elemIndices 1 [ 1, 2, 3 ]) [ 0 ]
+                    Expect.equal (List.Extra.elemIndices 1 [ 1, 2, 3 ]) [ 0 ]
             , test "doesn't find indices of non-present" <|
                 \() ->
-                    Expect.equal (elemIndices 4 [ 1, 2, 3 ]) []
+                    Expect.equal (List.Extra.elemIndices 4 [ 1, 2, 3 ]) []
             , test "finds all indices" <|
                 \() ->
-                    Expect.equal (elemIndices 1 [ 1, 2, 1 ]) [ 0, 2 ]
+                    Expect.equal (List.Extra.elemIndices 1 [ 1, 2, 1 ]) [ 0, 2 ]
             ]
         , describe "findIndex" <|
             [ test "finds index of value" <|
                 \() ->
-                    Expect.equal (findIndex (\x -> modBy 2 x == 0) [ 1, 2, 3 ]) (Just 1)
+                    Expect.equal (List.Extra.findIndex (\x -> modBy 2 x == 0) [ 1, 2, 3 ]) (Just 1)
             , test "doesn't find index of non-present" <|
                 \() ->
-                    Expect.equal (findIndex (\x -> modBy 2 x == 0) [ 1, 3, 5 ]) Nothing
+                    Expect.equal (List.Extra.findIndex (\x -> modBy 2 x == 0) [ 1, 3, 5 ]) Nothing
             , test "finds index of first match" <|
                 \() ->
-                    Expect.equal (findIndex (\x -> modBy 2 x == 0) [ 1, 2, 4 ]) (Just 1)
+                    Expect.equal (List.Extra.findIndex (\x -> modBy 2 x == 0) [ 1, 2, 4 ]) (Just 1)
             ]
         , describe "findIndices" <|
             [ test "finds singleton index" <|
                 \() ->
-                    Expect.equal (findIndices (\x -> modBy 2 x == 0) [ 1, 2, 3 ]) [ 1 ]
+                    Expect.equal (List.Extra.findIndices (\x -> modBy 2 x == 0) [ 1, 2, 3 ]) [ 1 ]
             , test "doesn't find indices of non-present" <|
                 \() ->
-                    Expect.equal (findIndices (\x -> modBy 2 x == 0) [ 1, 3, 5 ]) []
+                    Expect.equal (List.Extra.findIndices (\x -> modBy 2 x == 0) [ 1, 3, 5 ]) []
             , test "finds all indices" <|
                 \() ->
-                    Expect.equal (findIndices (\x -> modBy 2 x == 0) [ 1, 2, 4 ]) [ 1, 2 ]
+                    Expect.equal (List.Extra.findIndices (\x -> modBy 2 x == 0) [ 1, 2, 4 ]) [ 1, 2 ]
             ]
         , describe "findMap" <|
             [ test "Nothing for empty list" <|
                 \() ->
-                    Expect.equal (findMap identity []) Nothing
+                    Expect.equal (List.Extra.findMap identity []) Nothing
             , test "Finds and maps for list of one with first element matching" <|
                 \() ->
-                    Expect.equal (findMap List.head [ [ 1 ] ]) (Just 1)
+                    Expect.equal (List.Extra.findMap List.head [ [ 1 ] ]) (Just 1)
             , test "Fails to find and map for list of one without element matching" <|
                 \() ->
-                    Expect.equal (findMap List.head [ [] ]) Nothing
+                    Expect.equal (List.Extra.findMap List.head [ [] ]) Nothing
             , test "Finds and maps for list with middle element matching" <|
                 \() ->
-                    Expect.equal (findMap List.head [ [], [ 2 ], [] ]) (Just 2)
+                    Expect.equal (List.Extra.findMap List.head [ [], [ 2 ], [] ]) (Just 2)
             , test "Finds and maps for list with last element matching" <|
                 \() ->
-                    Expect.equal (findMap List.head [ [], [], [ 3 ] ]) (Just 3)
+                    Expect.equal (List.Extra.findMap List.head [ [], [], [ 3 ] ]) (Just 3)
             , test "Fails to find and map for list with no element matching" <|
                 \() ->
-                    Expect.equal (findMap List.head [ [], [], [] ]) Nothing
+                    Expect.equal (List.Extra.findMap List.head [ [], [], [] ]) Nothing
             ]
         , describe "count" <|
             [ test "isOdd predicate" <|
                 \() ->
-                    Expect.equal (count (\n -> modBy 2 n == 1) [ 1, 2, 3, 4, 5, 6, 7 ]) 4
+                    Expect.equal (List.Extra.count (\n -> modBy 2 n == 1) [ 1, 2, 3, 4, 5, 6, 7 ]) 4
             , test "equal predicate" <|
                 \() ->
-                    Expect.equal (count ((==) "yeah") [ "She", "loves", "you", "yeah", "yeah", "yeah" ]) 3
+                    Expect.equal (List.Extra.count ((==) "yeah") [ "She", "loves", "you", "yeah", "yeah", "yeah" ]) 3
             ]
         , describe "intercalate" <|
             [ test "computes example" <|
                 \() ->
                     Expect.equal
-                        (intercalate [ 0, 0 ] [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ])
+                        (List.Extra.intercalate [ 0, 0 ] [ [ 1, 2 ], [ 3, 4 ], [ 5, 6 ] ])
                         [ 1, 2, 0, 0, 3, 4, 0, 0, 5, 6 ]
             ]
         , describe "transpose" <|
             [ test "performs basic transpose" <|
                 \() ->
                     Expect.equal
-                        (transpose [ [ 1, 2, 3 ], [ 4, 5, 6 ] ])
+                        (List.Extra.transpose [ [ 1, 2, 3 ], [ 4, 5, 6 ] ])
                         [ [ 1, 4 ], [ 2, 5 ], [ 3, 6 ] ]
             , test "truncate the matrix to the shortest row size" <|
                 \() ->
                     Expect.equal
-                        (transpose [ [ 10, 11 ], [ 20 ], [ 30, 31, 32 ] ])
+                        (List.Extra.transpose [ [ 10, 11 ], [ 20 ], [ 30, 31, 32 ] ])
                         [ [ 10, 20, 30 ] ]
             , test "transposes large lists" <|
                 \() ->
                     Expect.equal
-                        (transpose [ List.repeat 10000 1 ])
+                        (List.Extra.transpose [ List.repeat 10000 1 ])
                         (List.repeat 10000 [ 1 ])
             ]
         , describe "subsequences" <|
             [ test "computes subsequences" <|
                 \() ->
                     Expect.equal
-                        (subsequences [ 1, 2, 3 ])
+                        (List.Extra.subsequences [ 1, 2, 3 ])
                         [ [], [ 1 ], [ 2 ], [ 1, 2 ], [ 3 ], [ 1, 3 ], [ 2, 3 ], [ 1, 2, 3 ] ]
             ]
         , describe "subsequencesNonEmpty" <|
             [ test "computes subsequences to non-empty lists" <|
                 \() ->
                     Expect.equal
-                        (subsequencesNonEmpty [ 1, 2, 3 ])
+                        (List.Extra.subsequencesNonEmpty [ 1, 2, 3 ])
                         [ ( 1, [] )
                         , ( 2, [] )
                         , ( 1, [ 2 ] )
@@ -177,13 +177,13 @@ all =
             [ test "computes permutations" <|
                 \() ->
                     Expect.equal
-                        (permutations [ 1, 2, 3 ])
+                        (List.Extra.permutations [ 1, 2, 3 ])
                         [ [ 1, 2, 3 ], [ 1, 3, 2 ], [ 2, 1, 3 ], [ 2, 3, 1 ], [ 3, 1, 2 ], [ 3, 2, 1 ] ]
             ]
         , describe "isPermutationOf"
             [ fuzz2 (Fuzz.list Fuzz.int) (Fuzz.list Fuzz.int) "works the same as sorting" <|
                 \a b ->
-                    isPermutationOf a b
+                    List.Extra.isPermutationOf a b
                         |> Expect.equal (List.sort a == List.sort b)
             , test "correctly notices permutations" <|
                 \() ->
@@ -192,18 +192,18 @@ all =
                             |> List.map
                                 (\permutation () ->
                                     permutation
-                                        |> isPermutationOf [ 1, 2, 3 ]
+                                        |> List.Extra.isPermutationOf [ 1, 2, 3 ]
                                         |> Expect.equal True
                                 )
                         )
                         ()
             , test "Notices that 1,1,1 is not a permutation of 1,2,3" <|
                 \() ->
-                    isPermutationOf [ 1, 1, 1 ] [ 1, 2, 3 ]
+                    List.Extra.isPermutationOf [ 1, 1, 1 ] [ 1, 2, 3 ]
                         |> Expect.equal False
             , test "Notices that 1,1,2 is not a permutation of 1,2,2" <|
                 \() ->
-                    isPermutationOf [ 1, 1, 2 ] [ 1, 2, 2 ]
+                    List.Extra.isPermutationOf [ 1, 1, 2 ] [ 1, 2, 2 ]
                         |> Expect.equal False
             , test "correctly notices non-permutations" <|
                 \() ->
@@ -212,7 +212,7 @@ all =
                             |> List.map
                                 (\nonPermutation () ->
                                     [ 1, 2, 3 ]
-                                        |> isPermutationOf nonPermutation
+                                        |> List.Extra.isPermutationOf nonPermutation
                                         |> Expect.equal False
                                 )
                         )
@@ -221,135 +221,135 @@ all =
         , describe "interweave" <|
             [ test "interweaves lists of equal length" <|
                 \() ->
-                    Expect.equal (interweave [ 1, 3 ] [ 2, 4 ]) [ 1, 2, 3, 4 ]
+                    Expect.equal (List.Extra.interweave [ 1, 3 ] [ 2, 4 ]) [ 1, 2, 3, 4 ]
             , test "appends remaining members of first list, if longer" <|
                 \() ->
-                    Expect.equal (interweave [ 1, 3, 5, 7 ] [ 2, 4 ]) [ 1, 2, 3, 4, 5, 7 ]
+                    Expect.equal (List.Extra.interweave [ 1, 3, 5, 7 ] [ 2, 4 ]) [ 1, 2, 3, 4, 5, 7 ]
             , test "appends remaining members of second list, if longer" <|
                 \() ->
-                    Expect.equal (interweave [ 4, 9, 16 ] [ 2, 3, 5, 7 ]) [ 4, 2, 9, 3, 16, 5, 7 ]
+                    Expect.equal (List.Extra.interweave [ 4, 9, 16 ] [ 2, 3, 5, 7 ]) [ 4, 2, 9, 3, 16, 5, 7 ]
             ]
         , describe "cartesianProduct" <|
             [ test "computes the cartesian product of lists of different length" <|
                 \() ->
-                    Expect.equal (cartesianProduct [ [ 1, 2 ], [ 3, 4, 5 ], [ 6 ] ]) [ [ 1, 3, 6 ], [ 1, 4, 6 ], [ 1, 5, 6 ], [ 2, 3, 6 ], [ 2, 4, 6 ], [ 2, 5, 6 ] ]
+                    Expect.equal (List.Extra.cartesianProduct [ [ 1, 2 ], [ 3, 4, 5 ], [ 6 ] ]) [ [ 1, 3, 6 ], [ 1, 4, 6 ], [ 1, 5, 6 ], [ 2, 3, 6 ], [ 2, 4, 6 ], [ 2, 5, 6 ] ]
             , test "computes the cartesian product of a single list" <|
                 \() ->
-                    Expect.equal (cartesianProduct [ [ 1, 2 ] ]) [ [ 1 ], [ 2 ] ]
+                    Expect.equal (List.Extra.cartesianProduct [ [ 1, 2 ] ]) [ [ 1 ], [ 2 ] ]
             , test "computes the cartesian product of lists including an empty one" <|
                 \() ->
-                    Expect.equal (cartesianProduct [ [ 1, 2 ], [], [ 6 ] ]) []
+                    Expect.equal (List.Extra.cartesianProduct [ [ 1, 2 ], [], [ 6 ] ]) []
             , test "computes the nullary cartesian product" <|
                 \() ->
-                    Expect.equal (cartesianProduct []) [ [] ]
+                    Expect.equal (List.Extra.cartesianProduct []) [ [] ]
             ]
         , describe "foldl1" <|
             [ test "computes minimum" <|
                 \() ->
-                    Expect.equal (foldl1 min [ 1, 2, 3, 2, 1 ]) (Just 1)
+                    Expect.equal (List.Extra.foldl1 min [ 1, 2, 3, 2, 1 ]) (Just 1)
             , test "computes left to right difference" <|
                 \() ->
-                    Expect.equal (foldl1 (-) [ 1, 2, 3, 4 ]) (Just 2)
+                    Expect.equal (List.Extra.foldl1 (-) [ 1, 2, 3, 4 ]) (Just 2)
             , test "concats in reverse" <|
                 \() ->
-                    Expect.equal (foldl1 (++) [ "a", "b", "c" ]) (Just "cba")
+                    Expect.equal (List.Extra.foldl1 (++) [ "a", "b", "c" ]) (Just "cba")
             , test "falls back to Nothing" <|
                 \() ->
-                    Expect.equal (foldl1 min []) Nothing
+                    Expect.equal (List.Extra.foldl1 min []) Nothing
             ]
         , describe "foldr1" <|
             [ test "computes minimum" <|
                 \() ->
-                    Expect.equal (foldr1 min [ 1, 2, 3, 2, 1 ]) (Just 1)
+                    Expect.equal (List.Extra.foldr1 min [ 1, 2, 3, 2, 1 ]) (Just 1)
             , test "computes right to left difference" <|
                 \() ->
-                    Expect.equal (foldr1 (-) [ 1, 2, 3, 4 ]) (Just -2)
+                    Expect.equal (List.Extra.foldr1 (-) [ 1, 2, 3, 4 ]) (Just -2)
             , test "concats properly" <|
                 \() ->
-                    Expect.equal (foldr1 (++) [ "a", "b", "c" ]) (Just "abc")
+                    Expect.equal (List.Extra.foldr1 (++) [ "a", "b", "c" ]) (Just "abc")
             , test "falls back to Nothing" <|
                 \() ->
-                    Expect.equal (foldr1 min []) Nothing
+                    Expect.equal (List.Extra.foldr1 min []) Nothing
             ]
         , describe "scanl1" <|
             [ test "computes left to right iterative sum" <|
                 \() ->
-                    Expect.equal (scanl1 (+) [ 1, 2, 3 ]) [ 1, 3, 6 ]
+                    Expect.equal (List.Extra.scanl1 (+) [ 1, 2, 3 ]) [ 1, 3, 6 ]
             , test "computes left to right iterative difference" <|
                 \() ->
-                    Expect.equal (scanl1 (-) [ 1, 2, 3 ]) [ 1, 1, 2 ]
+                    Expect.equal (List.Extra.scanl1 (-) [ 1, 2, 3 ]) [ 1, 1, 2 ]
             , test "computes left to right flipped iterative difference" <|
                 \() ->
-                    Expect.equal (scanl1 (\x y -> y - x) [ 1, 2, 3 ]) [ 1, -1, -4 ]
+                    Expect.equal (List.Extra.scanl1 (\x y -> y - x) [ 1, 2, 3 ]) [ 1, -1, -4 ]
             ]
         , describe "scanr" <|
             [ test "computes right to left iterative sum" <|
                 \() ->
-                    Expect.equal (scanr (+) 0 [ 1, 2, 3 ]) [ 6, 5, 3, 0 ]
+                    Expect.equal (List.Extra.scanr (+) 0 [ 1, 2, 3 ]) [ 6, 5, 3, 0 ]
             , test "computes right to left iterative difference" <|
                 \() ->
-                    Expect.equal (scanr (-) 0 [ 1, 2, 3 ]) [ 2, -1, 3, 0 ]
+                    Expect.equal (List.Extra.scanr (-) 0 [ 1, 2, 3 ]) [ 2, -1, 3, 0 ]
             ]
         , describe "scanr1" <|
             [ test "computes right to left iterative sum" <|
                 \() ->
-                    Expect.equal (scanr1 (+) [ 1, 2, 3 ]) [ 6, 5, 3 ]
+                    Expect.equal (List.Extra.scanr1 (+) [ 1, 2, 3 ]) [ 6, 5, 3 ]
             , test "computes right to left iterative difference" <|
                 \() ->
-                    Expect.equal (scanr1 (-) [ 1, 2, 3 ]) [ 2, -1, 3 ]
+                    Expect.equal (List.Extra.scanr1 (-) [ 1, 2, 3 ]) [ 2, -1, 3 ]
             , test "computes right to left flipped iterative difference" <|
                 \() ->
-                    Expect.equal (scanr1 (\x y -> y - x) [ 1, 2, 3 ]) [ 0, 1, 3 ]
+                    Expect.equal (List.Extra.scanr1 (\x y -> y - x) [ 1, 2, 3 ]) [ 0, 1, 3 ]
             ]
         , describe "mapAccuml" <|
             [ test "on empty list" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\a x -> ( a + x, a * x )) 5 [])
+                        (List.Extra.mapAccuml (\a x -> ( a + x, a * x )) 5 [])
                         ( 5, [] )
             , test "accumulate sum and map product" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ])
+                        (List.Extra.mapAccuml (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ])
                         ( 19, [ 10, 28, 88 ] )
             , test "running total" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\a x -> ( a + x, ( x, a + x ) )) 0 [ 2, 4, 8 ])
+                        (List.Extra.mapAccuml (\a x -> ( a + x, ( x, a + x ) )) 0 [ 2, 4, 8 ])
                         ( 14, [ ( 2, 2 ), ( 4, 6 ), ( 8, 14 ) ] )
             , test "works for very long list (i.e. is call stack size safe)" <|
                 \() ->
                     Expect.equal
-                        (mapAccuml (\a x -> ( a + x, () )) 0 (List.range 1 100000) |> Tuple.first)
+                        (List.Extra.mapAccuml (\a x -> ( a + x, () )) 0 (List.range 1 100000) |> Tuple.first)
                         5000050000
             ]
         , describe "mapAccumr" <|
             [ test "on empty list" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\a x -> ( a + x, a * x )) 5 [])
+                        (List.Extra.mapAccumr (\a x -> ( a + x, a * x )) 5 [])
                         ( 5, [] )
             , test "accumulate sum and map product" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ])
+                        (List.Extra.mapAccumr (\a x -> ( a + x, a * x )) 5 [ 2, 4, 8 ])
                         ( 19, [ 34, 52, 40 ] )
             , test "add count down" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\a x -> ( a + 1, ( x, a ) )) 0 [ 2, 4, 8 ])
+                        (List.Extra.mapAccumr (\a x -> ( a + 1, ( x, a ) )) 0 [ 2, 4, 8 ])
                         ( 3, [ ( 2, 2 ), ( 4, 1 ), ( 8, 0 ) ] )
             , test "works for very long list (i.e. is call stack size safe)" <|
                 \() ->
                     Expect.equal
-                        (mapAccumr (\a x -> ( a + x, () )) 0 (List.range 1 100000) |> Tuple.first)
+                        (List.Extra.mapAccumr (\a x -> ( a + x, () )) 0 (List.range 1 100000) |> Tuple.first)
                         5000050000
             ]
         , describe "unfoldr" <|
             [ test "builds a decreasing list from a seed" <|
                 \() ->
                     Expect.equal
-                        (unfoldr
+                        (List.Extra.unfoldr
                             (\b ->
                                 if b == 0 then
                                     Nothing
@@ -377,7 +377,7 @@ all =
                                     else
                                         3 * n + 1
                     in
-                    Expect.equal (iterate collatz 13) [ 13, 40, 20, 10, 5, 16, 8, 4, 2, 1 ]
+                    Expect.equal (List.Extra.iterate collatz 13) [ 13, 40, 20, 10, 5, 16, 8, 4, 2, 1 ]
             , test "should not raise RangeError" <|
                 \() ->
                     let
@@ -389,48 +389,48 @@ all =
                                 Just (n + 1)
 
                         val =
-                            iterate loop 1
+                            List.Extra.iterate loop 1
                     in
                     Expect.equal (List.length val) 100000
             ]
         , describe "init" <|
             [ test "handles an empty list" <|
                 \() ->
-                    Expect.equal (init []) Nothing
+                    Expect.equal (List.Extra.init []) Nothing
             , fuzz Fuzz.int "handles a nearly-empty list" <|
                 \x ->
-                    Expect.equal (init [ x ]) (Just [])
+                    Expect.equal (List.Extra.init [ x ]) (Just [])
             , fuzz2 (Fuzz.list Fuzz.int) Fuzz.int "handles a non-empty list" <|
                 \list x ->
-                    Expect.equal (init <| list ++ [ x ]) (Just list)
+                    Expect.equal (List.Extra.init <| list ++ [ x ]) (Just list)
             ]
         , describe "initialize" <|
             [ test "creates a list starting from zero" <|
                 \() ->
-                    Expect.equal (initialize 5 identity) [ 0, 1, 2, 3, 4 ]
+                    Expect.equal (List.Extra.initialize 5 identity) [ 0, 1, 2, 3, 4 ]
             , test "creates a list by doubling the index" <|
                 \() ->
-                    Expect.equal (initialize 5 (\x -> x * 2)) [ 0, 2, 4, 6, 8 ]
+                    Expect.equal (List.Extra.initialize 5 (\x -> x * 2)) [ 0, 2, 4, 6, 8 ]
             , test "creates a list of identical values" <|
                 \() ->
-                    Expect.equal (initialize 1 (always 3)) [ 3 ]
+                    Expect.equal (List.Extra.initialize 1 (always 3)) [ 3 ]
             ]
         , describe "cycle" <|
             [ test "same length" <|
                 \() ->
-                    Expect.equal (cycle 3 [ 4, 7, 8 ]) [ 4, 7, 8 ]
+                    Expect.equal (List.Extra.cycle 3 [ 4, 7, 8 ]) [ 4, 7, 8 ]
             , test "multiple of length" <|
                 \() ->
-                    Expect.equal (cycle 6 [ 4, 7, 8 ]) [ 4, 7, 8, 4, 7, 8 ]
+                    Expect.equal (List.Extra.cycle 6 [ 4, 7, 8 ]) [ 4, 7, 8, 4, 7, 8 ]
             , test "partial cycle" <|
                 \() ->
-                    Expect.equal (cycle 4 [ 'a', 'b', 'c' ]) [ 'a', 'b', 'c', 'a' ]
+                    Expect.equal (List.Extra.cycle 4 [ 'a', 'b', 'c' ]) [ 'a', 'b', 'c', 'a' ]
             , test "empty list" <|
                 \() ->
-                    Expect.equal (cycle 9001 []) []
+                    Expect.equal (List.Extra.cycle 9001 []) []
             , test "resulting length smaller than cycle length" <|
                 \() ->
-                    Expect.equal (cycle 2 [ 1, 2, 3, 4, 5 ]) [ 1, 2 ]
+                    Expect.equal (List.Extra.cycle 2 [ 1, 2, 3, 4, 5 ]) [ 1, 2 ]
             ]
         , describe "reverseRange"
             [ let
@@ -442,206 +442,206 @@ all =
               in
               fuzz2 (Fuzz.intRange rangeFloor rangeCeiling) (Fuzz.intRange rangeFloor rangeCeiling) "always equal to the reverse of List.range" <|
                 \hi lo ->
-                    reverseRange hi lo
+                    List.Extra.reverseRange hi lo
                         |> Expect.equalLists (List.reverse (List.range lo hi))
             ]
         , describe "splitAt" <|
             [ test "splits a list in the middle" <|
                 \() ->
-                    Expect.equal (splitAt 3 [ 1, 2, 3, 4, 5 ]) ( [ 1, 2, 3 ], [ 4, 5 ] )
+                    Expect.equal (List.Extra.splitAt 3 [ 1, 2, 3, 4, 5 ]) ( [ 1, 2, 3 ], [ 4, 5 ] )
             , test "splits a list at the first element" <|
                 \() ->
-                    Expect.equal (splitAt 1 [ 1, 2, 3 ]) ( [ 1 ], [ 2, 3 ] )
+                    Expect.equal (List.Extra.splitAt 1 [ 1, 2, 3 ]) ( [ 1 ], [ 2, 3 ] )
             , test "splits the entire list correctly" <|
                 \() ->
-                    Expect.equal (splitAt 3 [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+                    Expect.equal (List.Extra.splitAt 3 [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
             , test "splits past the length of the list" <|
                 \() ->
-                    Expect.equal (splitAt 4 [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+                    Expect.equal (List.Extra.splitAt 4 [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
             , test "handles zero correctly" <|
                 \() ->
-                    Expect.equal (splitAt 0 [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+                    Expect.equal (List.Extra.splitAt 0 [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
             , test "handles negative numbers correctly" <|
                 \() ->
-                    Expect.equal (splitAt -1 [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+                    Expect.equal (List.Extra.splitAt -1 [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
             ]
         , describe "splitWhen" <|
             [ test "returns split list when predicate is true" <|
                 \() ->
-                    Expect.equal (splitWhen (\n -> n == 3) [ 1, 2, 3, 4, 5 ]) (Just ( [ 1, 2 ], [ 3, 4, 5 ] ))
+                    Expect.equal (List.Extra.splitWhen (\n -> n == 3) [ 1, 2, 3, 4, 5 ]) (Just ( [ 1, 2 ], [ 3, 4, 5 ] ))
             , test "returns nothing when predicate is false" <|
                 \() ->
-                    Expect.equal (splitWhen (\n -> n == 6) [ 1, 2, 3, 4, 5 ]) Nothing
+                    Expect.equal (List.Extra.splitWhen (\n -> n == 6) [ 1, 2, 3, 4, 5 ]) Nothing
             ]
         , describe "takeWhileRight" <|
             [ test "keeps the correct items" <|
                 \() ->
-                    Expect.equal (takeWhileRight ((<) 5) (List.range 1 10)) [ 6, 7, 8, 9, 10 ]
+                    Expect.equal (List.Extra.takeWhileRight (\x -> 5 < x) (List.range 1 10)) [ 6, 7, 8, 9, 10 ]
             , test "drops the correct items" <|
                 \() ->
-                    Expect.equal (dropWhileRight ((<) 5) (List.range 1 10)) [ 1, 2, 3, 4, 5 ]
+                    Expect.equal (List.Extra.dropWhileRight (\x -> 5 < x) (List.range 1 10)) [ 1, 2, 3, 4, 5 ]
             ]
         , describe "takeWhile" <|
             [ test "doesn't exceed maximum call stack" <|
                 \() ->
-                    Expect.equal (takeWhile ((>) 19999) (List.range 1 20000)) (List.range 1 19998)
+                    Expect.equal (List.Extra.takeWhile (\x -> 19999 > x) (List.range 1 20000)) (List.range 1 19998)
             ]
         , describe "span" <|
             [ test "splits in the middle of the list" <|
                 \() ->
-                    Expect.equal (span ((>) 3) [ 1, 2, 3, 4, 1, 2, 3, 4 ]) ( [ 1, 2 ], [ 3, 4, 1, 2, 3, 4 ] )
+                    Expect.equal (List.Extra.span (\x -> 3 > x) [ 1, 2, 3, 4, 1, 2, 3, 4 ]) ( [ 1, 2 ], [ 3, 4, 1, 2, 3, 4 ] )
             , test "every element passes predicate" <|
                 \() ->
-                    Expect.equal (span ((>) 5) [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+                    Expect.equal (List.Extra.span (\x -> 5 > x) [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
             , test "first item doesn't pass predicate" <|
                 \() ->
-                    Expect.equal (span ((>) 0) [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+                    Expect.equal (List.Extra.span (\x -> 0 > x) [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
             ]
         , describe "break" <|
             [ test "breaks in the middle of the list" <|
                 \() ->
-                    Expect.equal (break ((<) 3) [ 1, 2, 3, 4, 1, 2, 3, 4 ]) ( [ 1, 2, 3 ], [ 4, 1, 2, 3, 4 ] )
+                    Expect.equal (List.Extra.break (\x -> 3 < x) [ 1, 2, 3, 4, 1, 2, 3, 4 ]) ( [ 1, 2, 3 ], [ 4, 1, 2, 3, 4 ] )
             , test "breaks on the first item" <|
                 \() ->
-                    Expect.equal (break ((>) 5) [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
+                    Expect.equal (List.Extra.break (\x -> 5 > x) [ 1, 2, 3 ]) ( [], [ 1, 2, 3 ] )
             , test "doesn't break for any element" <|
                 \() ->
-                    Expect.equal (break ((<) 5) [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
+                    Expect.equal (List.Extra.break (\x -> 5 < x) [ 1, 2, 3 ]) ( [ 1, 2, 3 ], [] )
             ]
         , describe "stripPrefix" <|
             [ test "removes a matching prefix" <|
                 \() ->
-                    Expect.equal (stripPrefix [ 1, 2 ] [ 1, 2, 3, 4 ]) (Just [ 3, 4 ])
+                    Expect.equal (List.Extra.stripPrefix [ 1, 2 ] [ 1, 2, 3, 4 ]) (Just [ 3, 4 ])
             , test "removes a matching 3-element prefix" <|
                 \() ->
-                    Expect.equal (stripPrefix [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]) (Just [ 4, 5 ])
+                    Expect.equal (List.Extra.stripPrefix [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ]) (Just [ 4, 5 ])
             , test "can remove the entire list" <|
                 \() ->
-                    Expect.equal (stripPrefix [ 1, 2, 3 ] [ 1, 2, 3 ]) (Just [])
+                    Expect.equal (List.Extra.stripPrefix [ 1, 2, 3 ] [ 1, 2, 3 ]) (Just [])
             , test "fails when prefix is longer than list" <|
                 \() ->
-                    Expect.equal (stripPrefix [ 1, 2, 3 ] [ 1, 2 ]) Nothing
+                    Expect.equal (List.Extra.stripPrefix [ 1, 2, 3 ] [ 1, 2 ]) Nothing
             , test "fails when list doesn't contain prefix" <|
                 \() ->
-                    Expect.equal (stripPrefix [ 3, 2, 1 ] [ 1, 2, 3, 4, 5 ]) Nothing
+                    Expect.equal (List.Extra.stripPrefix [ 3, 2, 1 ] [ 1, 2, 3, 4, 5 ]) Nothing
             ]
         , describe "group" <|
             [ test "groups elements correctly" <|
                 \() ->
-                    Expect.equal (group [ 1, 2, 2, 3, 3, 3, 2, 2, 1 ])
+                    Expect.equal (List.Extra.group [ 1, 2, 2, 3, 3, 3, 2, 2, 1 ])
                         [ ( 1, [] ), ( 2, [ 2 ] ), ( 3, [ 3, 3 ] ), ( 2, [ 2 ] ), ( 1, [] ) ]
             ]
         , describe "groupWhile" <|
             [ test "groups by sub-element equality" <|
                 \() ->
                     Expect.equal
-                        (groupWhile (\( x, _ ) ( y, _ ) -> x == y) [ ( 0, 'a' ), ( 0, 'b' ), ( 1, 'c' ), ( 1, 'd' ) ])
+                        (List.Extra.groupWhile (\( x, _ ) ( y, _ ) -> x == y) [ ( 0, 'a' ), ( 0, 'b' ), ( 1, 'c' ), ( 1, 'd' ) ])
                         [ ( ( 0, 'a' ), [ ( 0, 'b' ) ] ), ( ( 1, 'c' ), [ ( 1, 'd' ) ] ) ]
             , test "comparison function is reflexive, symmetric, and transitive" <|
                 \() ->
                     Expect.equal
-                        (groupWhile (<) [ 1, 2, 3, 2, 4, 1, 3, 2, 1 ])
+                        (List.Extra.groupWhile (<) [ 1, 2, 3, 2, 4, 1, 3, 2, 1 ])
                         [ ( 1, [ 2, 3 ] ), ( 2, [ 4 ] ), ( 1, [ 3 ] ), ( 2, [] ), ( 1, [] ) ]
             ]
         , describe "inits" <|
             [ test "returns all initial segments" <|
                 \() ->
-                    Expect.equal (inits [ 1, 2, 3 ]) [ [], [ 1 ], [ 1, 2 ], [ 1, 2, 3 ] ]
+                    Expect.equal (List.Extra.inits [ 1, 2, 3 ]) [ [], [ 1 ], [ 1, 2 ], [ 1, 2, 3 ] ]
             ]
         , describe "tails" <|
             [ test "returns all final segments" <|
                 \() ->
-                    Expect.equal (tails [ 1, 2, 3 ]) [ [ 1, 2, 3 ], [ 2, 3 ], [ 3 ], [] ]
+                    Expect.equal (List.Extra.tails [ 1, 2, 3 ]) [ [ 1, 2, 3 ], [ 2, 3 ], [ 3 ], [] ]
             ]
         , describe "select" <|
             [ test "returns all variations with a single item removed" <|
                 \() ->
                     Expect.equal
-                        (select [ 1, 2, 3, 4 ])
+                        (List.Extra.select [ 1, 2, 3, 4 ])
                         [ ( 1, [ 2, 3, 4 ] ), ( 2, [ 1, 3, 4 ] ), ( 3, [ 1, 2, 4 ] ), ( 4, [ 1, 2, 3 ] ) ]
             ]
         , describe "selectSplit" <|
             [ test "returns all splits at a single item" <|
                 \() ->
-                    Expect.equal (selectSplit [ 1, 2, 3 ]) [ ( [], 1, [ 2, 3 ] ), ( [ 1 ], 2, [ 3 ] ), ( [ 1, 2 ], 3, [] ) ]
+                    Expect.equal (List.Extra.selectSplit [ 1, 2, 3 ]) [ ( [], 1, [ 2, 3 ] ), ( [ 1 ], 2, [ 3 ] ), ( [ 1, 2 ], 3, [] ) ]
             ]
         , describe "isSubsequenceOf" <|
             [ test "success" <|
                 \() ->
-                    isSubsequenceOf [ "E", "l", "m" ] [ "E", "a", "t", " ", "l", "i", "m", "e", "s" ]
+                    List.Extra.isSubsequenceOf [ "E", "l", "m" ] [ "E", "a", "t", " ", "l", "i", "m", "e", "s" ]
                         |> Expect.equal True
                         |> Expect.onFail "Elm is a subsequence of Eat lime"
             , test "failure" <|
                 \() ->
-                    isSubsequenceOf [ "E", "l", "m" ] [ "E", "m", "a", "i", "l" ]
+                    List.Extra.isSubsequenceOf [ "E", "l", "m" ] [ "E", "m", "a", "i", "l" ]
                         |> Expect.equal False
                         |> Expect.onFail "Elm is not a subsequence of Email"
             , test "success at last element" <|
                 \() ->
-                    isSubsequenceOf [ 1, 3 ] [ 1, 2, 3 ]
+                    List.Extra.isSubsequenceOf [ 1, 3 ] [ 1, 2, 3 ]
                         |> Expect.equal True
                         |> Expect.onFail "[] should be a subsequence of []"
             ]
         , describe "lift2" <|
             [ test "produces all combinations of addition" <|
                 \() ->
-                    Expect.equal (lift2 (+) [ 1, 2, 3 ] [ 4, 5 ]) [ 5, 6, 6, 7, 7, 8 ]
+                    Expect.equal (List.Extra.lift2 (+) [ 1, 2, 3 ] [ 4, 5 ]) [ 5, 6, 6, 7, 7, 8 ]
             ]
         , describe "groupsOf" <|
             [ test "groups by the correct number of items" <|
                 \() ->
-                    Expect.equal (groupsOf 3 (List.range 1 10))
+                    Expect.equal (List.Extra.groupsOf 3 (List.range 1 10))
                         [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]
             ]
         , describe "groupsOfWithStep" <|
             [ test "step == size" <|
                 \() ->
-                    Expect.equal (groupsOfWithStep 4 4 (List.range 1 10))
+                    Expect.equal (List.Extra.groupsOfWithStep 4 4 (List.range 1 10))
                         [ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ] ]
             , test "step < size" <|
                 \() ->
-                    Expect.equal (groupsOfWithStep 3 1 (List.range 1 5))
+                    Expect.equal (List.Extra.groupsOfWithStep 3 1 (List.range 1 5))
                         [ [ 1, 2, 3 ], [ 2, 3, 4 ], [ 3, 4, 5 ] ]
             , test "step > size" <|
                 \() ->
-                    Expect.equal (groupsOfWithStep 3 6 (List.range 1 20))
+                    Expect.equal (List.Extra.groupsOfWithStep 3 6 (List.range 1 20))
                         [ [ 1, 2, 3 ], [ 7, 8, 9 ], [ 13, 14, 15 ] ]
             ]
         , describe "groupsOfVarying" <|
             [ test "group sizes match passed sizes" <|
                 \() ->
                     Expect.equal
-                        (groupsOfVarying [ 2, 3, 1 ] [ "a", "b", "c", "d", "e", "f" ])
+                        (List.Extra.groupsOfVarying [ 2, 3, 1 ] [ "a", "b", "c", "d", "e", "f" ])
                         [ [ "a", "b" ], [ "c", "d", "e" ], [ "f" ] ]
             , test "groups correctly when passed counts are less than list size" <|
                 \() ->
                     Expect.equal
-                        (groupsOfVarying [ 2 ] [ "a", "b", "c", "d", "e", "f" ])
+                        (List.Extra.groupsOfVarying [ 2 ] [ "a", "b", "c", "d", "e", "f" ])
                         [ [ "a", "b" ] ]
             , test "groups correctly when passed counts are greater than list size" <|
                 \() ->
                     Expect.equal
-                        (groupsOfVarying [ 2, 3, 1, 5, 6 ] [ "a", "b", "c", "d", "e" ])
+                        (List.Extra.groupsOfVarying [ 2, 3, 1, 5, 6 ] [ "a", "b", "c", "d", "e" ])
                         [ [ "a", "b" ], [ "c", "d", "e" ] ]
             ]
         , describe "greedyGroupsOf" <|
             [ test "groups correctly while keeping trailing group" <|
                 \() ->
-                    Expect.equal (greedyGroupsOf 3 (List.range 1 10))
+                    Expect.equal (List.Extra.greedyGroupsOf 3 (List.range 1 10))
                         [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10 ] ]
             ]
         , describe "greedyGroupsOfWithStep" <|
             [ test "step == size" <|
                 \() ->
-                    Expect.equal (greedyGroupsOfWithStep 4 4 (List.range 1 10))
+                    Expect.equal (List.Extra.greedyGroupsOfWithStep 4 4 (List.range 1 10))
                         [ [ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10 ] ]
             , test "step < size" <|
                 \() ->
-                    Expect.equal (greedyGroupsOfWithStep 3 2 (List.range 1 6))
+                    Expect.equal (List.Extra.greedyGroupsOfWithStep 3 2 (List.range 1 6))
                         [ [ 1, 2, 3 ], [ 3, 4, 5 ], [ 5, 6 ] ]
             , test "step > size" <|
                 \() ->
-                    Expect.equal (greedyGroupsOfWithStep 3 6 (List.range 1 20))
+                    Expect.equal (List.Extra.greedyGroupsOfWithStep 3 6 (List.range 1 20))
                         [ [ 1, 2, 3 ], [ 7, 8, 9 ], [ 13, 14, 15 ], [ 19, 20 ] ]
             ]
         , describe "isPrefixOf"
@@ -672,12 +672,12 @@ all =
                         |> Expect.onFail "Expected prefix of prefix to be prefix."
             , test "stack safety" <|
                 \() ->
-                    isPrefixOf (List.range 1 6000) (List.range 1 10000)
+                    List.Extra.isPrefixOf (List.range 1 6000) (List.range 1 10000)
                         |> Expect.equal True
                         |> Expect.onFail "1, 2, ..., 6k is prefix of 1, 2, ..., 10k"
             , fuzz2 (Fuzz.list Fuzz.int) (Fuzz.list Fuzz.int) "generalized fuzz test" <|
                 \prefix rest ->
-                    isPrefixOf prefix (prefix ++ rest)
+                    List.Extra.isPrefixOf prefix (prefix ++ rest)
                         |> Expect.equal True
                         |> Expect.onFail "xs is prefix of xs ++ ys"
             ]
@@ -709,144 +709,144 @@ all =
                         |> Expect.onFail "Expected suffix of suffix to be suffix."
             , test "stack safety" <|
                 \() ->
-                    isSuffixOf (List.range 4000 10000) (List.range 1 10000)
+                    List.Extra.isSuffixOf (List.range 4000 10000) (List.range 1 10000)
                         |> Expect.equal True
                         |> Expect.onFail "4000, 4001, ..., 10k is suffix of 1, 2, ..., 10k"
             , fuzz2 (Fuzz.list Fuzz.int) (Fuzz.list Fuzz.int) "generalized fuzz test" <|
                 \suffix rest ->
-                    isSuffixOf suffix (rest ++ suffix)
+                    List.Extra.isSuffixOf suffix (rest ++ suffix)
                         |> Expect.equal True
                         |> Expect.onFail "ys is suffix of xs ++ ys"
             ]
         , describe "isInfixOf"
             [ test "success" <|
                 \() ->
-                    isInfixOf [ 5, 7, 11 ] [ 2, 3, 5, 7, 11, 13 ]
+                    List.Extra.isInfixOf [ 5, 7, 11 ] [ 2, 3, 5, 7, 11, 13 ]
                         |> Expect.equal True
                         |> Expect.onFail "5, 7, 11 is infix of 2, 3, 5, 7, 11, 13"
             , test "not consecutive" <|
                 \() ->
-                    isInfixOf [ 5, 7, 13 ] [ 2, 3, 5, 7, 11, 13 ]
+                    List.Extra.isInfixOf [ 5, 7, 13 ] [ 2, 3, 5, 7, 11, 13 ]
                         |> Expect.equal False
                         |> Expect.onFail "5, 7, 13 is not infix of 2, 3, 5, 7, 11, 13"
             , test "not in-order" <|
                 \() ->
-                    isInfixOf [ 3, 5, 2 ] [ 2, 3, 5, 7, 11, 13 ]
+                    List.Extra.isInfixOf [ 3, 5, 2 ] [ 2, 3, 5, 7, 11, 13 ]
                         |> Expect.equal False
                         |> Expect.onFail "3, 5, 2 is not infix of 2, 3, 5, 7, 11, 13"
             , test "partial match then real match" <|
                 \() ->
-                    isInfixOf [ 1, 2 ] [ 1, 3, 1, 2 ]
+                    List.Extra.isInfixOf [ 1, 2 ] [ 1, 3, 1, 2 ]
                         |> Expect.equal True
                         |> Expect.onFail "1, 2 is infix of 1, 3, 1, 2"
             , test "stack safety" <|
                 \() ->
-                    isInfixOf (List.range 1 6000) (List.range 1 10000)
+                    List.Extra.isInfixOf (List.range 1 6000) (List.range 1 10000)
                         |> Expect.equal True
                         |> Expect.onFail "1, 2, ..., 6k is infix of 1, 2, ..., 10k"
             , fuzz3 (Fuzz.list Fuzz.int) (Fuzz.list Fuzz.int) (Fuzz.list Fuzz.int) "generalized fuzz test" <|
                 \prefix match suffix ->
-                    isInfixOf match (prefix ++ match ++ suffix)
+                    List.Extra.isInfixOf match (prefix ++ match ++ suffix)
                         |> Expect.equal True
                         |> Expect.onFail "ys is infix of xs ++ ys ++ zs"
             , test "empty is infix of empty" <|
                 \() ->
-                    isInfixOf [] []
+                    List.Extra.isInfixOf [] []
                         |> Expect.equal True
                         |> Expect.onFail "empty is infix of empty"
             , fuzz (Fuzz.list Fuzz.int) "empty is infix of anything" <|
                 \list ->
-                    isInfixOf [] list
+                    List.Extra.isInfixOf [] list
                         |> Expect.equal True
                         |> Expect.onFail "empty is infix of anything"
             , fuzz2 Fuzz.int (Fuzz.list Fuzz.int) "non-empty is not infix of empty" <|
                 \x xs ->
-                    isInfixOf (x :: xs) []
+                    List.Extra.isInfixOf (x :: xs) []
                         |> Expect.equal False
                         |> Expect.onFail "non-empty is not infix of empty"
             , fuzz (Fuzz.list Fuzz.int) "equal lists are infix" <|
                 \list ->
-                    isInfixOf list list
+                    List.Extra.isInfixOf list list
                         |> Expect.equal True
                         |> Expect.onFail "equal lists are infix"
             , test "is stack safe" <|
                 \() ->
-                    isInfixOf [ 5, 7, 13 ] (List.repeat 1000000 5)
+                    List.Extra.isInfixOf [ 5, 7, 13 ] (List.repeat 1000000 5)
                         |> Expect.equal False
                         |> Expect.onFail "5, 7, 13 is not infix of 2, 3, 5, 7, 11, 13"
             ]
         , describe "swapAt"
             [ test "negative index as first argument returns the original list" <|
                 \() ->
-                    Expect.equal (swapAt -1 0 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.swapAt -1 0 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "negative index as second argument returns the original list" <|
                 \() ->
-                    Expect.equal (swapAt 0 -1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.swapAt 0 -1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "out of range index as first argument returns the original list" <|
                 \() ->
-                    Expect.equal (swapAt 10 0 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.swapAt 10 0 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "out of range index as second argument returns the original list" <|
                 \() ->
-                    Expect.equal (swapAt 0 -1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.swapAt 0 -1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "identical indexes returns the original list" <|
                 \() ->
-                    Expect.equal (swapAt 1 1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.swapAt 1 1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "swap the elements at indices 0 and 1" <|
                 \() ->
-                    Expect.equal (swapAt 0 1 [ 1, 2, 3 ]) [ 2, 1, 3 ]
+                    Expect.equal (List.Extra.swapAt 0 1 [ 1, 2, 3 ]) [ 2, 1, 3 ]
             ]
         , describe "removeAt"
             [ test "negative index returns the original list" <|
                 \() ->
-                    Expect.equal (removeAt -1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.removeAt -1 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "remove the element at index 0" <|
                 \() ->
-                    Expect.equal (removeAt 0 [ 1, 2, 3 ]) [ 2, 3 ]
+                    Expect.equal (List.Extra.removeAt 0 [ 1, 2, 3 ]) [ 2, 3 ]
             , test "remove the element at index 2" <|
                 \() ->
-                    Expect.equal (removeAt 2 [ 1, 2, 3 ]) [ 1, 2 ]
+                    Expect.equal (List.Extra.removeAt 2 [ 1, 2, 3 ]) [ 1, 2 ]
             , test "out of range index returns the original list" <|
                 \() ->
-                    Expect.equal (removeAt 4 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.removeAt 4 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             ]
         , describe "setAt"
             [ test "negative index returns the original list" <|
                 \() ->
-                    Expect.equal (setAt -1 9 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.setAt -1 9 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "set index 0 to 9" <|
                 \() ->
-                    Expect.equal (setAt 0 9 [ 1, 2, 3 ]) [ 9, 2, 3 ]
+                    Expect.equal (List.Extra.setAt 0 9 [ 1, 2, 3 ]) [ 9, 2, 3 ]
             , test "set index 2 to 9" <|
                 \() ->
-                    Expect.equal (setAt 2 9 [ 1, 2, 3 ]) [ 1, 2, 9 ]
+                    Expect.equal (List.Extra.setAt 2 9 [ 1, 2, 3 ]) [ 1, 2, 9 ]
             , test "out of range index returns the original list" <|
                 \() ->
-                    Expect.equal (setAt 4 9 [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.setAt 4 9 [ 1, 2, 3 ]) [ 1, 2, 3 ]
             ]
         , describe "updateAt"
             [ test "negative index returns the original list" <|
                 \() ->
-                    Expect.equal (updateAt -1 ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.updateAt -1 ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 3 ]
             , test "increment the element at index 0" <|
                 \() ->
-                    Expect.equal (updateAt 0 ((+) 1) [ 1, 2, 3 ]) [ 2, 2, 3 ]
+                    Expect.equal (List.Extra.updateAt 0 ((+) 1) [ 1, 2, 3 ]) [ 2, 2, 3 ]
             , test "increment the element at index 2" <|
                 \() ->
-                    Expect.equal (updateAt 2 ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 4 ]
+                    Expect.equal (List.Extra.updateAt 2 ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 4 ]
             , test "out of range index returns the original list" <|
                 \() ->
-                    Expect.equal (updateAt 4 ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 3 ]
+                    Expect.equal (List.Extra.updateAt 4 ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 3 ]
             ]
         , describe "updateIfIndex"
             [ test "increments first element" <|
                 \() ->
-                    Expect.equal (updateIfIndex (always True) ((+) 1) [ 1, 2, 3 ]) [ 2, 3, 4 ]
+                    Expect.equal (List.Extra.updateIfIndex (always True) ((+) 1) [ 1, 2, 3 ]) [ 2, 3, 4 ]
             , test "if the index is 2, then increment the element" <|
                 \() ->
-                    Expect.equal (updateIfIndex ((==) 2) ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 4 ]
+                    Expect.equal (List.Extra.updateIfIndex ((==) 2) ((+) 1) [ 1, 2, 3 ]) [ 1, 2, 4 ]
             , test "if the index is even, increment the element" <|
                 \() ->
-                    Expect.equal (updateIfIndex (\index -> modBy 2 index == 0) ((+) 1) [ 1, 2, 3 ]) [ 2, 2, 4 ]
+                    Expect.equal (List.Extra.updateIfIndex (\index -> modBy 2 index == 0) ((+) 1) [ 1, 2, 3 ]) [ 2, 2, 4 ]
             ]
         , describe "remove"
             [ test "leaves the list untouched if the value is not in the list" <|
@@ -857,17 +857,17 @@ all =
                             [ 1, 2, 3 ]
                     in
                     list
-                        |> remove 1000
+                        |> List.Extra.remove 1000
                         |> Expect.equal list
             , test "removes the element if it's present in the list" <|
                 \() ->
                     [ 1, 2, 3 ]
-                        |> remove 2
+                        |> List.Extra.remove 2
                         |> Expect.equal [ 1, 3 ]
             , test "removes only the first element" <|
                 \() ->
                     [ 1, 2, 3, 3, 3 ]
-                        |> remove 3
+                        |> List.Extra.remove 3
                         |> Expect.equal [ 1, 2, 3, 3 ]
             , test "is stack-safe" <|
                 \() ->
@@ -877,87 +877,87 @@ all =
                             List.range 1 10000
                     in
                     list
-                        |> remove 100000
+                        |> List.Extra.remove 100000
                         |> Expect.equal list
             ]
         , describe "removeIfIndex"
             [ test "remove all the elements" <|
                 \() ->
-                    Expect.equal (removeIfIndex (always True) [ 1, 2, 3 ]) []
+                    Expect.equal (List.Extra.removeIfIndex (always True) [ 1, 2, 3 ]) []
             , test "remove the element at index 2" <|
                 \() ->
-                    Expect.equal (removeIfIndex ((==) 2) [ 1, 2, 3 ]) [ 1, 2 ]
+                    Expect.equal (List.Extra.removeIfIndex ((==) 2) [ 1, 2, 3 ]) [ 1, 2 ]
             , test "remove all elements at even indices" <|
                 \() ->
-                    Expect.equal (removeIfIndex (\index -> modBy 2 index == 0) [ 1, 2, 3 ]) [ 2 ]
+                    Expect.equal (List.Extra.removeIfIndex (\index -> modBy 2 index == 0) [ 1, 2, 3 ]) [ 2 ]
             ]
         , describe "unconsLast"
             [ test "removes last element of list" <|
                 \() ->
-                    Expect.equal (unconsLast [ 1, 2, 3 ]) (Just ( 3, [ 1, 2 ] ))
+                    Expect.equal (List.Extra.unconsLast [ 1, 2, 3 ]) (Just ( 3, [ 1, 2 ] ))
             , test "returns Nothing if the list is empty" <|
                 \() ->
-                    Expect.equal (unconsLast []) Nothing
+                    Expect.equal (List.Extra.unconsLast []) Nothing
             ]
         , describe "maximumWith"
             [ test "maximum of empty list" <|
                 \() ->
-                    Expect.equal (maximumWith compare []) Nothing
+                    Expect.equal (List.Extra.maximumWith compare []) Nothing
             , test "first maximum of records list" <|
                 \() ->
                     Expect.equal
-                        (maximumWith (\x y -> compare x.val y.val) [ { id = 1, val = 1 }, { id = 2, val = 2 }, { id = 3, val = 2 } ])
+                        (List.Extra.maximumWith (\x y -> compare x.val y.val) [ { id = 1, val = 1 }, { id = 2, val = 2 }, { id = 3, val = 2 } ])
                         (Just { id = 2, val = 2 })
             ]
         , describe "maximumBy"
             [ test "maximumBy of empty list" <|
-                \() -> Expect.equal (maximumBy (\x -> x) []) Nothing
+                \() -> Expect.equal (List.Extra.maximumBy (\x -> x) []) Nothing
             , test "first maximumBy of records list" <|
                 \() ->
-                    Expect.equal (maximumBy (\x -> x.val) [ { id = 1, val = 1 }, { id = 2, val = 2 }, { id = 3, val = 2 } ])
+                    Expect.equal (List.Extra.maximumBy (\x -> x.val) [ { id = 1, val = 1 }, { id = 2, val = 2 }, { id = 3, val = 2 } ])
                         (Just { id = 2, val = 2 })
             ]
         , describe "minimumWith"
             [ test "minimum of empty list" <|
                 \() ->
-                    Expect.equal (minimumWith compare []) Nothing
+                    Expect.equal (List.Extra.minimumWith compare []) Nothing
             , test "first minimum of records list" <|
                 \() ->
                     Expect.equal
-                        (minimumWith (\x y -> compare x.val y.val) [ { id = 1, val = 2 }, { id = 2, val = 1 }, { id = 3, val = 1 } ])
+                        (List.Extra.minimumWith (\x y -> compare x.val y.val) [ { id = 1, val = 2 }, { id = 2, val = 1 }, { id = 3, val = 1 } ])
                         (Just { id = 2, val = 1 })
             ]
         , describe "minimumBy"
             [ test "minimumBy of empty list" <|
-                \() -> Expect.equal (minimumBy (\x -> x) []) Nothing
+                \() -> Expect.equal (List.Extra.minimumBy (\x -> x) []) Nothing
             , test "first minimumBy of records list" <|
                 \() ->
-                    Expect.equal (minimumBy (\x -> x.val) [ { id = 1, val = 2 }, { id = 2, val = 1 }, { id = 3, val = 1 } ])
+                    Expect.equal (List.Extra.minimumBy (\x -> x.val) [ { id = 1, val = 2 }, { id = 2, val = 1 }, { id = 3, val = 1 } ])
                         (Just { id = 2, val = 1 })
             ]
         , describe "setIf"
             [ test "empty list" <|
                 \() ->
-                    Expect.equal (setIf ((==) 1) 0 []) []
+                    Expect.equal (List.Extra.setIf ((==) 1) 0 []) []
             , test "set all" <|
                 \() ->
-                    Expect.equal (setIf (always True) 2 [ 1, 2, 3, 4 ]) [ 2, 2, 2, 2 ]
+                    Expect.equal (List.Extra.setIf (always True) 2 [ 1, 2, 3, 4 ]) [ 2, 2, 2, 2 ]
             , test "set only evens" <|
                 \() ->
-                    Expect.equal (setIf (\x -> modBy 2 x == 0) 0 [ 17, 8, 2, 9 ]) [ 17, 0, 0, 9 ]
+                    Expect.equal (List.Extra.setIf (\x -> modBy 2 x == 0) 0 [ 17, 8, 2, 9 ]) [ 17, 0, 0, 9 ]
             ]
         , describe "gatherEquals"
             [ test "empty list" <|
                 \() ->
-                    gatherEquals []
+                    List.Extra.gatherEquals []
                         |> Expect.equal []
             , test "single element" <|
                 \() ->
-                    gatherEquals [ 1 ]
+                    List.Extra.gatherEquals [ 1 ]
                         |> Expect.equal [ ( 1, [] ) ]
             , test "proper test" <|
                 \() ->
-                    gatherEquals [ 1, 2, 1, 2, 3, 4, 1 ]
+                    List.Extra.gatherEquals [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
                             [ ( 1, [ 1, 1 ] )
                             , ( 2, [ 2 ] )
@@ -968,15 +968,15 @@ all =
         , describe "gatherEqualsBy"
             [ test "empty list" <|
                 \() ->
-                    gatherEqualsBy identity []
+                    List.Extra.gatherEqualsBy identity []
                         |> Expect.equal []
             , test "single element" <|
                 \() ->
-                    gatherEqualsBy identity [ 1 ]
+                    List.Extra.gatherEqualsBy identity [ 1 ]
                         |> Expect.equal [ ( 1, [] ) ]
             , test "proper test" <|
                 \() ->
-                    gatherEqualsBy identity [ 1, 2, 1, 2, 3, 4, 1 ]
+                    List.Extra.gatherEqualsBy identity [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
                             [ ( 1, [ 1, 1 ] )
                             , ( 2, [ 2 ] )
@@ -987,15 +987,15 @@ all =
         , describe "gatherWith"
             [ test "empty list" <|
                 \() ->
-                    gatherWith (==) []
+                    List.Extra.gatherWith (==) []
                         |> Expect.equal []
             , test "single element" <|
                 \() ->
-                    gatherWith (==) [ 1 ]
+                    List.Extra.gatherWith (==) [ 1 ]
                         |> Expect.equal [ ( 1, [] ) ]
             , test "proper test" <|
                 \() ->
-                    gatherWith (==) [ 1, 2, 1, 2, 3, 4, 1 ]
+                    List.Extra.gatherWith (==) [ 1, 2, 1, 2, 3, 4, 1 ]
                         |> Expect.equal
                             [ ( 1, [ 1, 1 ] )
                             , ( 2, [ 2 ] )
@@ -1006,54 +1006,54 @@ all =
         , describe "uniquePairs"
             [ test "empty list" <|
                 \() ->
-                    uniquePairs []
+                    List.Extra.uniquePairs []
                         |> Expect.equal []
             , test "single element has no counterpart to pair with" <|
                 \() ->
-                    uniquePairs [ 1 ]
+                    List.Extra.uniquePairs [ 1 ]
                         |> Expect.equal []
             , test "two elements have exactly one way to pair" <|
                 \() ->
-                    uniquePairs [ 1, 2 ]
+                    List.Extra.uniquePairs [ 1, 2 ]
                         |> Expect.equal [ ( 1, 2 ) ]
             , test "three elements have three ways to pair" <|
                 \() ->
-                    uniquePairs [ 1, 2, 3 ]
+                    List.Extra.uniquePairs [ 1, 2, 3 ]
                         |> Expect.equal [ ( 1, 2 ), ( 1, 3 ), ( 2, 3 ) ]
             ]
         , describe "joinOn"
             [ test "with first list empty" <|
                 \() ->
-                    joinOn Tuple.pair identity identity [] [ 1, 2, 3 ]
+                    List.Extra.joinOn Tuple.pair identity identity [] [ 1, 2, 3 ]
                         |> Expect.equal []
             , test "with second list empty" <|
                 \() ->
-                    joinOn Tuple.pair identity identity [ 1, 2, 3 ] []
+                    List.Extra.joinOn Tuple.pair identity identity [ 1, 2, 3 ] []
                         |> Expect.equal []
             , test "with neither list empty" <|
                 \() ->
-                    joinOn Tuple.pair identity identity [ 1, 3, 2 ] [ 2, 1, 3 ]
+                    List.Extra.joinOn Tuple.pair identity identity [ 1, 3, 2 ] [ 2, 1, 3 ]
                         |> Expect.equal [ ( 3, 3 ), ( 2, 2 ), ( 1, 1 ) ]
             ]
         , describe "frequencies"
             [ describe "Property testing with fuzz"
                 [ fuzz (Fuzz.list Fuzz.int) "Final value similar list and List.sort list" <|
                     \list ->
-                        frequencies list
+                        List.Extra.frequencies list
                             |> List.sort
-                            |> Expect.equal (frequencies list)
+                            |> Expect.equal (List.Extra.frequencies list)
                 , fuzz (Fuzz.list Fuzz.int) "Final value similar, no matter the order of composition for frequencies and List.sort" <|
                     \list ->
                         let
                             freqFirst =
                                 list
-                                    |> frequencies
+                                    |> List.Extra.frequencies
                                     |> List.sort
 
                             sortFirst =
                                 list
                                     |> List.sort
-                                    |> frequencies
+                                    |> List.Extra.frequencies
                         in
                         freqFirst
                             |> Expect.equal sortFirst
@@ -1061,19 +1061,19 @@ all =
                     \list1 list2 ->
                         let
                             areListsSimilar =
-                                isPermutationOf list2 list1
+                                List.Extra.isPermutationOf list2 list1
 
                             freq1 =
-                                frequencies list1
+                                List.Extra.frequencies list1
 
                             freq2 =
-                                frequencies list2
+                                List.Extra.frequencies list2
 
                             shouldFreqsBeSimilar =
                                 areListsSimilar
 
                             areFreqsSimilar =
-                                isPermutationOf freq2 freq1
+                                List.Extra.isPermutationOf freq2 freq1
                         in
                         areFreqsSimilar
                             |> Expect.equal shouldFreqsBeSimilar
@@ -1081,26 +1081,26 @@ all =
             , describe "Unit testing on basic examples"
                 [ test "Frequencies on List Int" <|
                     \() ->
-                        frequencies [ 4, 1, 3, 2, 2, 4, 3, 3, 4, 4 ]
+                        List.Extra.frequencies [ 4, 1, 3, 2, 2, 4, 3, 3, 4, 4 ]
                             |> Expect.equal [ ( 1, 1 ), ( 2, 2 ), ( 3, 3 ), ( 4, 4 ) ]
                 , test "Frequencies on List String" <|
                     \() ->
-                        frequencies [ "a", "b", "aa", "c", "b", "aa", "c", "C", "C", "D" ]
+                        List.Extra.frequencies [ "a", "b", "aa", "c", "b", "aa", "c", "C", "C", "D" ]
                             |> Expect.equal [ ( "C", 2 ), ( "D", 1 ), ( "a", 1 ), ( "aa", 2 ), ( "b", 2 ), ( "c", 2 ) ]
                 , test "Frequencies on empty List a" <|
                     \() ->
-                        frequencies []
+                        List.Extra.frequencies []
                             |> Expect.equal []
                 ]
             ]
         , describe "stoppableFoldl"
             [ fuzz (Fuzz.list Fuzz.int) "behaves like foldl if function always returns Continue" <|
                 \xs ->
-                    stoppableFoldl (\n acc -> Continue (n + acc)) 0 xs
+                    List.Extra.stoppableFoldl (\n acc -> Continue (n + acc)) 0 xs
                         |> Expect.equal (List.sum xs)
             , test "simple example" <|
                 \() ->
-                    stoppableFoldl
+                    List.Extra.stoppableFoldl
                         (\n acc ->
                             if acc >= 50 then
                                 Stop acc
@@ -1122,7 +1122,7 @@ all =
                         throwRangeErrorException ()
                 in
                 \() ->
-                    stoppableFoldl
+                    List.Extra.stoppableFoldl
                         (\n _ ->
                             if n < 50 then
                                 Continue n

--- a/tests/MaybeTests.elm
+++ b/tests/MaybeTests.elm
@@ -2,7 +2,7 @@ module MaybeTests exposing (suite)
 
 import Array
 import Expect
-import Maybe.Extra exposing (..)
+import Maybe.Extra
 import Test exposing (Test, describe, test)
 
 
@@ -13,69 +13,69 @@ suite =
             [ test "both Just" <|
                 \() ->
                     Just 4
-                        |> orElse (Just 5)
+                        |> Maybe.Extra.orElse (Just 5)
                         |> Expect.equal (Just 4)
             , test "pipe input Nothing" <|
                 \() ->
                     Nothing
-                        |> orElse (Just 5)
+                        |> Maybe.Extra.orElse (Just 5)
                         |> Expect.equal (Just 5)
             , test "pipe function Nothing" <|
                 \() ->
                     Just 4
-                        |> orElse Nothing
+                        |> Maybe.Extra.orElse Nothing
                         |> Expect.equal (Just 4)
             , test "both Nothing" <|
                 \() ->
                     Nothing
-                        |> orElse Nothing
+                        |> Maybe.Extra.orElse Nothing
                         |> Expect.equal Nothing
             ]
         , describe "orLazy"
             [ test "both Just" <|
                 \() ->
-                    orLazy (Just 4) (\() -> Just 5)
+                    Maybe.Extra.orLazy (Just 4) (\() -> Just 5)
                         |> Expect.equal (Just 4)
             , test "first Nothing" <|
                 \() ->
-                    orLazy Nothing (\() -> Just 5)
+                    Maybe.Extra.orLazy Nothing (\() -> Just 5)
                         |> Expect.equal (Just 5)
             , test "second Nothing" <|
                 \() ->
-                    orLazy (Just 4) (\() -> Nothing)
+                    Maybe.Extra.orLazy (Just 4) (\() -> Nothing)
                         |> Expect.equal (Just 4)
             , test "both Nothing" <|
                 \() ->
-                    orLazy Nothing (\() -> Nothing)
+                    Maybe.Extra.orLazy Nothing (\() -> Nothing)
                         |> Expect.equal Nothing
             ]
         , describe "orElseLazy"
             [ test "both Just" <|
                 \() ->
                     Just 4
-                        |> orElseLazy (\() -> Just 5)
+                        |> Maybe.Extra.orElseLazy (\() -> Just 5)
                         |> Expect.equal (Just 4)
             , test "pipe input Nothing" <|
                 \() ->
                     Nothing
-                        |> orElseLazy (\() -> Just 5)
+                        |> Maybe.Extra.orElseLazy (\() -> Just 5)
                         |> Expect.equal (Just 5)
             , test "pipe function Nothing" <|
                 \() ->
                     Just 4
-                        |> orElseLazy (\() -> Nothing)
+                        |> Maybe.Extra.orElseLazy (\() -> Nothing)
                         |> Expect.equal (Just 4)
             , test "both Nothing" <|
                 \() ->
                     Nothing
-                        |> orElseLazy (\() -> Nothing)
+                        |> Maybe.Extra.orElseLazy (\() -> Nothing)
                         |> Expect.equal Nothing
             ]
         , describe "orListLazy"
             [ test "empty" <|
                 \() ->
                     []
-                        |> orListLazy
+                        |> Maybe.Extra.orListLazy
                         |> Expect.equal Nothing
             , test "all nothing" <|
                 \() ->
@@ -83,70 +83,70 @@ suite =
                     , \() -> Nothing
                     , \() -> String.toInt ""
                     ]
-                        |> orListLazy
+                        |> Maybe.Extra.orListLazy
                         |> Expect.equal Nothing
             ]
         , describe "traverseArray"
             [ test "empty" <|
                 \() ->
                     Array.empty
-                        |> traverseArray (\x -> Just (x * 10))
+                        |> Maybe.Extra.traverseArray (\x -> Just (x * 10))
                         |> Expect.equal (Just Array.empty)
             , test "all Just" <|
                 \() ->
                     [ 1, 2, 3, 4, 5 ]
                         |> Array.fromList
-                        |> traverseArray (\x -> Just (x * 10))
+                        |> Maybe.Extra.traverseArray (\x -> Just (x * 10))
                         |> Expect.equal (Just (Array.fromList [ 10, 20, 30, 40, 50 ]))
             , test "one Nothing fails the whole function" <|
                 \() ->
                     [ [ 1 ], [ 2, 3 ], [] ]
                         |> Array.fromList
-                        |> traverseArray List.head
+                        |> Maybe.Extra.traverseArray List.head
                         |> Expect.equal Nothing
             ]
         , describe "combineArray"
             [ test "empty" <|
                 \() ->
                     Array.empty
-                        |> combineArray
+                        |> Maybe.Extra.combineArray
                         |> Expect.equal (Just Array.empty)
             , test "succeed" <|
                 \() ->
                     [ Just 1, Just 2, Just 3 ]
                         |> Array.fromList
-                        |> combineArray
+                        |> Maybe.Extra.combineArray
                         |> Expect.equal (Just (Array.fromList [ 1, 2, 3 ]))
             , test "fail" <|
                 \() ->
                     [ Just 1, Nothing ]
                         |> Array.fromList
-                        |> combineArray
+                        |> Maybe.Extra.combineArray
                         |> Expect.equal Nothing
             ]
         , describe "oneOf"
             [ test "empty" <|
                 \() ->
-                    oneOf [] 0
+                    Maybe.Extra.oneOf [] 0
                         |> Expect.equal Nothing
             , test "all fail" <|
                 \() ->
-                    oneOf (List.repeat 10 (always Nothing)) 0
+                    Maybe.Extra.oneOf (List.repeat 10 (always Nothing)) 0
                         |> Expect.equal Nothing
             , test "last function succeeds" <|
                 \() ->
-                    oneOf [ always Nothing, always Nothing, always Nothing, always (Just True) ] 0
+                    Maybe.Extra.oneOf [ always Nothing, always Nothing, always Nothing, always (Just True) ] 0
                         |> Expect.equal (Just True)
             , test "first function succeeds" <|
                 \() ->
                     0
-                        |> oneOf [ Just, Just << (+) 10, Just << (+) 20 ]
+                        |> Maybe.Extra.oneOf [ Just, Just << (+) 10, Just << (+) 20 ]
                         |> Expect.equal (Just 0)
             ]
         , describe "andThen3"
             [ test "returns a Just if it can" <|
                 \() ->
-                    andThen3
+                    Maybe.Extra.andThen3
                         (\a b c -> Just (a + b + c))
                         (Just 4)
                         (Just 2)
@@ -156,7 +156,7 @@ suite =
         , describe "andThen4"
             [ test "returns a Just if it can" <|
                 \() ->
-                    andThen4
+                    Maybe.Extra.andThen4
                         (\a b c d -> Just (a + b + c + d))
                         (Just 8)
                         (Just 4)
@@ -167,21 +167,21 @@ suite =
         , describe "unwrap"
             [ test "returns the default value if it is a Nothing" <|
                 \() ->
-                    unwrap 0 String.length Nothing
+                    Maybe.Extra.unwrap 0 String.length Nothing
                         |> Expect.equal 0
             , test "returns the unwrapped value if it is a Just" <|
                 \() ->
-                    unwrap 0 String.length (Just "abc")
+                    Maybe.Extra.unwrap 0 String.length (Just "abc")
                         |> Expect.equal 3
             ]
         , describe "unpack"
             [ test "returns the default value if it is a Nothing" <|
                 \() ->
-                    unpack (\() -> 0) String.length Nothing
+                    Maybe.Extra.unpack (\() -> 0) String.length Nothing
                         |> Expect.equal 0
             , test "returns the unpackped value if it is a Just" <|
                 \() ->
-                    unpack (\() -> 0) String.length (Just "abc")
+                    Maybe.Extra.unpack (\() -> 0) String.length (Just "abc")
                         |> Expect.equal 3
             ]
         ]

--- a/tests/String/CamelizeTest.elm
+++ b/tests/String/CamelizeTest.elm
@@ -4,7 +4,7 @@ import Expect
 import Fuzz exposing (Fuzzer)
 import Regex
 import String exposing (replace)
-import String.Extra exposing (..)
+import String.Extra exposing (camelize)
 import String.TestData as TestData
 import Test exposing (Test, describe, fuzz)
 
@@ -60,7 +60,7 @@ runCamelize separator string =
 capitalizeOdds : Int -> String -> String
 capitalizeOdds pos str =
     if pos > 0 then
-        toSentenceCase str
+        String.Extra.toSentenceCase str
 
     else
         str

--- a/tests/String/ClassifyTest.elm
+++ b/tests/String/ClassifyTest.elm
@@ -5,7 +5,7 @@ import Expect
 import Fuzz exposing (Fuzzer)
 import Regex
 import String exposing (replace, uncons)
-import String.Extra exposing (..)
+import String.Extra exposing (classify)
 import String.TestData as TestData
 import Test exposing (Test, describe, fuzz)
 import Tuple exposing (first, second)
@@ -33,7 +33,7 @@ classifyTest =
                     |> classify
                     |> uncons
                     |> Maybe.map second
-                    |> Expect.equal (string |> replace "." "-" |> camelize |> uncons |> Maybe.map second)
+                    |> Expect.equal (string |> replace "." "-" |> String.Extra.camelize |> uncons |> Maybe.map second)
         ]
 
 

--- a/tests/String/HumanizeTest.elm
+++ b/tests/String/HumanizeTest.elm
@@ -5,7 +5,7 @@ import Expect
 import Fuzz exposing (Fuzzer)
 import Regex
 import String
-import String.Extra exposing (..)
+import String.Extra exposing (humanize)
 import String.TestData as TestData
 import Test exposing (Test, describe, fuzz, test)
 import Tuple exposing (first, second)
@@ -43,7 +43,7 @@ humanizeTest =
                 let
                     expected =
                         String.trim
-                            >> toSentenceCase
+                            >> String.Extra.toSentenceCase
                             >> String.uncons
                             >> Maybe.map (first >> String.fromChar)
                             >> Maybe.withDefault ""

--- a/tests/String/ReplaceSliceTest.elm
+++ b/tests/String/ReplaceSliceTest.elm
@@ -3,7 +3,7 @@ module String.ReplaceSliceTest exposing (replaceSliceTest)
 import Expect
 import Fuzz exposing (Fuzzer)
 import String
-import String.Extra exposing (..)
+import String.Extra
 import Test exposing (Test, describe, fuzz)
 
 
@@ -14,11 +14,11 @@ replaceSliceTest =
             \{ string, start, end, sub } ->
                 case string of
                     "" ->
-                        replaceSlice sub start end string
+                        String.Extra.replaceSlice sub start end string
                             |> Expect.equal sub
 
                     _ ->
-                        replaceSlice sub start end string
+                        String.Extra.replaceSlice sub start end string
                             |> String.contains sub
                             |> Expect.equal True
                             |> Expect.onFail "The slice was not subtituted"
@@ -26,30 +26,30 @@ replaceSliceTest =
             \{ string, start, end, sub } ->
                 case string of
                     "" ->
-                        replaceSlice sub start end string
+                        String.Extra.replaceSlice sub start end string
                             |> String.length
                             |> Expect.equal (String.length sub)
 
                     _ ->
-                        replaceSlice sub start end string
+                        String.Extra.replaceSlice sub start end string
                             |> String.length
                             |> Expect.equal ((String.length string - (end - start)) + String.length sub)
         , fuzz replaceSliceProducer "Start of the original string remains the same" <|
             \{ string, start, end, sub } ->
                 case string of
                     "" ->
-                        replaceSlice sub start end string
+                        String.Extra.replaceSlice sub start end string
                             |> Expect.equal sub
 
                     _ ->
-                        replaceSlice sub start end string
+                        String.Extra.replaceSlice sub start end string
                             |> String.slice 0 start
                             |> Expect.equal (String.slice 0 start string)
         , fuzz replaceSliceProducer "End of the original string remains the same" <|
             \{ string, start, end, sub } ->
                 let
                     replaced =
-                        replaceSlice sub start end string
+                        String.Extra.replaceSlice sub start end string
                 in
                 case string of
                     "" ->

--- a/tests/String/Tests.elm
+++ b/tests/String/Tests.elm
@@ -5,7 +5,7 @@ import Expect
 import Fuzz exposing (Fuzzer, string)
 import Regex exposing (Regex)
 import String exposing (fromChar, replace, toLower, toUpper, uncons)
-import String.Extra exposing (..)
+import String.Extra
 import Test exposing (Test, describe, fuzz, fuzz2, test)
 import Tuple exposing (first, second)
 
@@ -23,7 +23,7 @@ toSentenceCaseTest =
                 let
                     result =
                         string
-                            |> toSentenceCase
+                            |> String.Extra.toSentenceCase
                             |> uncons
                             |> Maybe.map (first >> fromChar)
                             |> Maybe.withDefault ""
@@ -39,7 +39,7 @@ toSentenceCaseTest =
             \string ->
                 let
                     result =
-                        (toSentenceCase >> tail) string
+                        (String.Extra.toSentenceCase >> tail) string
 
                     expected =
                         tail string
@@ -56,7 +56,7 @@ decapitalizeTest =
                 let
                     result =
                         string
-                            |> decapitalize
+                            |> String.Extra.decapitalize
                             |> uncons
                             |> Maybe.map (first >> fromChar)
                             |> Maybe.withDefault ""
@@ -72,7 +72,7 @@ decapitalizeTest =
             \string ->
                 let
                     result =
-                        (decapitalize >> tail) string
+                        (String.Extra.decapitalize >> tail) string
 
                     expected =
                         tail string
@@ -90,14 +90,14 @@ toTitleCaseTest =
                     result =
                         strings
                             |> String.join " "
-                            |> toTitleCase
+                            |> String.Extra.toTitleCase
                             |> String.words
 
                     expected =
                         strings
                             |> String.join " "
                             |> String.words
-                            |> List.map toSentenceCase
+                            |> List.map String.Extra.toSentenceCase
                 in
                 Expect.equal expected result
         , fuzz (Fuzz.list Fuzz.string) "It does not change the length of the string" <|
@@ -106,7 +106,7 @@ toTitleCaseTest =
                     result =
                         strings
                             |> String.join " "
-                            |> toTitleCase
+                            |> String.Extra.toTitleCase
                             |> String.length
 
                     expected =
@@ -125,29 +125,29 @@ breakTest =
             \string width ->
                 case ( string, width ) of
                     ( "", _ ) ->
-                        break width string
+                        String.Extra.break width string
                             |> List.length
                             |> Expect.equal 1
 
                     ( _, 0 ) ->
-                        break width string
+                        String.Extra.break width string
                             |> List.length
                             |> Expect.equal 1
 
                     _ ->
-                        break width string
+                        String.Extra.break width string
                             |> List.length
                             |> Expect.equal (ceiling <| (toFloat << String.length) string / toFloat width)
         , fuzz2 Fuzz.string (Fuzz.intRange 1 10) "Concatenating the result yields the original string" <|
             \string width ->
-                break width string
+                String.Extra.break width string
                     |> String.concat
                     |> Expect.equal string
         , fuzz2 Fuzz.string (Fuzz.intRange 1 10) "No element in the list should have more than `width` chars" <|
             \string width ->
-                break width string
+                String.Extra.break width string
                     |> List.map String.length
-                    |> List.filter ((<) width)
+                    |> List.filter (\x -> width < x)
                     |> List.isEmpty
                     |> Expect.equal True
                     |> Expect.onFail "The list has some long elements"
@@ -159,12 +159,12 @@ softBreakTest =
     describe "softBreak"
         [ fuzz2 Fuzz.string (Fuzz.intRange 1 10) "Concatenating the result yields the original string" <|
             \string width ->
-                softBreak width (String.trim string)
+                String.Extra.softBreak width (String.trim string)
                     |> String.concat
                     |> Expect.equal (String.trim string)
         , fuzz2 Fuzz.string (Fuzz.intRange 1 10) "The list should not have more elements than words" <|
             \string width ->
-                softBreak width string
+                String.Extra.softBreak width string
                     |> List.length
                     |> Expect.atMost (String.words string |> List.length)
         ]
@@ -191,14 +191,14 @@ cleanTest =
           fuzz Fuzz.string "It trims the string on the left side" <|
             \string ->
                 string
-                    |> clean
+                    |> String.Extra.clean
                     |> String.startsWith " "
                     |> Expect.equal False
                     |> Expect.onFail "Did not trim the start of the string"
         , fuzz Fuzz.string "It trims the string on the right side" <|
             \string ->
                 string
-                    |> clean
+                    |> String.Extra.clean
                     |> String.endsWith " "
                     |> Expect.equal False
                     |> Expect.onFail "Did not trim the end of the string"
@@ -211,23 +211,23 @@ insertAtTest =
         [ fuzz insertAtProducer "Result contains the substitution string" <|
             \( sub, at, string ) ->
                 string
-                    |> insertAt sub at
+                    |> String.Extra.insertAt sub at
                     |> String.contains sub
                     |> Expect.equal True
                     |> Expect.onFail "Could not find substitution string in result"
         , fuzz insertAtProducer "Resulting string has length as the sum of both arguments" <|
             \( sub, at, string ) ->
-                insertAt sub at string
+                String.Extra.insertAt sub at string
                     |> String.length
                     |> Expect.equal (String.length sub + String.length string)
         , fuzz insertAtProducer "Start of the string remains the same" <|
             \( sub, at, string ) ->
-                insertAt sub at string
+                String.Extra.insertAt sub at string
                     |> String.slice 0 at
                     |> Expect.equal (String.slice 0 at string)
         , fuzz insertAtProducer "End of the string remains the same" <|
             \( sub, at, string ) ->
-                insertAt sub at string
+                String.Extra.insertAt sub at string
                     |> String.slice (at + String.length sub) (String.length string + String.length sub)
                     |> Expect.equal (String.slice at (String.length string) string)
         ]
@@ -246,12 +246,12 @@ isBlankTest =
     describe "isBlank"
         [ test "Returns true if the given string is blank" <|
             \_ ->
-                isBlank ""
+                String.Extra.isBlank ""
                     |> Expect.equal True
                     |> Expect.onFail "Did not return true"
         , test "Returns false if the given string is not blank" <|
             \_ ->
-                isBlank " Slartibartfast"
+                String.Extra.isBlank " Slartibartfast"
                     |> Expect.equal False
                     |> Expect.onFail "Did not return false"
         ]
@@ -262,11 +262,11 @@ nonBlankTest =
     describe "nonBlank"
         [ test "Returns Nothing if the given string is blank" <|
             \_ ->
-                nonBlank ""
+                String.Extra.nonBlank ""
                     |> Expect.equal Nothing
         , test "Returns just the string if the given string is not blank" <|
             \_ ->
-                nonBlank " Slartibartfast"
+                String.Extra.nonBlank " Slartibartfast"
                     |> Expect.equal (Just " Slartibartfast")
         ]
 
@@ -277,21 +277,21 @@ surroundTest =
         [ fuzz2 Fuzz.string Fuzz.string "It starts with the wrapping string" <|
             \string wrap ->
                 string
-                    |> surround wrap
+                    |> String.Extra.surround wrap
                     |> String.startsWith wrap
                     |> Expect.equal True
                     |> Expect.onFail "Did not start with the wrapping string"
         , fuzz2 Fuzz.string Fuzz.string "It ends with the wrapping string" <|
             \string wrap ->
                 string
-                    |> surround wrap
+                    |> String.Extra.surround wrap
                     |> String.endsWith wrap
                     |> Expect.equal True
                     |> Expect.onFail "Did not end with the wrapping string"
         , fuzz2 Fuzz.string Fuzz.string "It contains the original string" <|
             \string wrap ->
                 string
-                    |> surround wrap
+                    |> String.Extra.surround wrap
                     |> String.contains string
                     |> Expect.equal True
                     |> Expect.onFail "Did not contain the string"
@@ -299,7 +299,7 @@ surroundTest =
             \string wrap ->
                 let
                     result =
-                        String.length (surround wrap string)
+                        String.length (String.Extra.surround wrap string)
 
                     expected =
                         String.length string + (2 * String.length wrap)
@@ -320,7 +320,7 @@ countOccurrencesTest =
             \needle haystack ->
                 let
                     times =
-                        countOccurrences needle haystack
+                        String.Extra.countOccurrences needle haystack
 
                     result =
                         String.length haystack - (times * String.length needle)
@@ -337,16 +337,16 @@ ellipsisTest =
     describe "ellipsis"
         [ fuzz2 (Fuzz.intRange 3 20) Fuzz.string "The resulting string length does not exceed the specified length" <|
             \howLong string ->
-                ellipsis howLong string
+                String.Extra.ellipsis howLong string
                     |> String.length
-                    |> (>=) howLong
+                    |> (\x -> howLong >= x)
                     |> Expect.equal True
                     |> Expect.onFail "Resulting string exceeds specified length"
         , fuzz2 (Fuzz.intRange 3 20) Fuzz.string "The resulting string contains three dots at the end if necessary" <|
             \howLong string ->
                 let
                     result =
-                        ellipsis howLong string
+                        String.Extra.ellipsis howLong string
                 in
                 result
                     |> String.endsWith "..."
@@ -360,7 +360,7 @@ ellipsisTest =
             \howLong string ->
                 let
                     result =
-                        ellipsis howLong string
+                        String.Extra.ellipsis howLong string
 
                     resultLeft =
                         String.dropRight 3 result
@@ -377,7 +377,7 @@ unquoteTest =
     describe "unquote"
         [ test "Removes quotes from the start of the string" <|
             \_ ->
-                unquote "\"Magrathea\""
+                String.Extra.unquote "\"Magrathea\""
                     |> Expect.equal "Magrathea"
         ]
 
@@ -387,7 +387,7 @@ wrapTest =
     describe "wrap"
         [ fuzz2 (Fuzz.intRange 1 20) Fuzz.string "Wraps given string at the requested length" <|
             \howLong string ->
-                wrap howLong string
+                String.Extra.wrap howLong string
                     |> String.split "\n"
                     |> List.map (\str -> String.length str <= howLong)
                     |> List.all ((==) True)
@@ -395,7 +395,7 @@ wrapTest =
                     |> Expect.onFail "Given string was not wrapped at requested length"
         , test "Does not wrap string shorter than the requested length" <|
             \_ ->
-                wrap 50 "Heart of Gold"
+                String.Extra.wrap 50 "Heart of Gold"
                     |> String.contains "\n"
                     |> Expect.equal False
                     |> Expect.onFail "Short string was wrapped"
@@ -407,15 +407,15 @@ pluralizeTest =
     describe "pluralize"
         [ test "It uses the singular version when the count is one" <|
             \() ->
-                pluralize "elf" "elves" 1
+                String.Extra.pluralize "elf" "elves" 1
                     |> Expect.equal "1 elf"
         , test "It uses the plural version for > 1 count" <|
             \() ->
-                pluralize "elf" "elves" 4
+                String.Extra.pluralize "elf" "elves" 4
                     |> Expect.equal "4 elves"
         , test "It uses the plural version for 0 count" <|
             \() ->
-                pluralize "elf" "elves" 0
+                String.Extra.pluralize "elf" "elves" 0
                     |> Expect.equal "0 elves"
         ]
 
@@ -424,7 +424,7 @@ leftOfBackTest : Test
 leftOfBackTest =
     test "leftOfBack" <|
         \() ->
-            leftOfBack "_" "This_is_a_test_string"
+            String.Extra.leftOfBack "_" "This_is_a_test_string"
                 |> Expect.equal "This_is_a_test"
 
 
@@ -432,18 +432,18 @@ rightOfBackTest : Test
 rightOfBackTest =
     test "rightOfBack" <|
         \() ->
-            rightOfBack "_" "This_is_a_test_string"
+            String.Extra.rightOfBack "_" "This_is_a_test_string"
                 |> Expect.equal "string"
 
 
 underscoredTest : Test
 underscoredTest =
-    underscoredDasherizeTestHelper underscored "_" "underscored"
+    underscoredDasherizeTestHelper String.Extra.underscored "_" "underscored"
 
 
 dasherizeTest : Test
 dasherizeTest =
-    underscoredDasherizeTestHelper dasherize "-" "dasherize"
+    underscoredDasherizeTestHelper String.Extra.dasherize "-" "dasherize"
 
 
 underscoredDasherizeTestHelper : (String -> String) -> String -> String -> Test

--- a/tests/String/UnicodeTests.elm
+++ b/tests/String/UnicodeTests.elm
@@ -4,7 +4,7 @@ import Char
 import Expect
 import Fuzz exposing (Fuzzer)
 import String
-import String.Extra exposing (..)
+import String.Extra
 import Test exposing (Test, describe, fuzz, test)
 
 
@@ -85,30 +85,30 @@ unicodeTests =
     describe "unicode"
         [ fuzz unicodeStringFuzzer "fromCodePoints is inverse of toCodePoints" <|
             \string ->
-                fromCodePoints (toCodePoints string)
+                String.Extra.fromCodePoints (String.Extra.toCodePoints string)
                     |> Expect.equal string
         , fuzz (Fuzz.list codePointFuzzer) "toCodePoints is inverse of fromCodePoints" <|
             \codePoints ->
-                toCodePoints (fromCodePoints codePoints)
+                String.Extra.toCodePoints (String.Extra.fromCodePoints codePoints)
                     |> Expect.equal codePoints
         , fuzz (Fuzz.list codePointFuzzer) "string length is greater than or equal to number of code points" <|
             \codePoints ->
-                String.length (fromCodePoints codePoints)
+                String.length (String.Extra.fromCodePoints codePoints)
                     |> Expect.atLeast (List.length codePoints)
         , fuzz unicodeStringFuzzer "number of code points is less than or equal to string length" <|
             \string ->
-                List.length (toCodePoints string)
+                List.length (String.Extra.toCodePoints string)
                     |> Expect.atMost (String.length string)
         , fuzz (Fuzz.list codePointFuzzer) "encoded string length is as expected" <|
             \codePoints ->
-                String.length (fromCodePoints codePoints)
+                String.length (String.Extra.fromCodePoints codePoints)
                     |> Expect.equal (expectedStringLength codePoints)
         , describe "toCodePoints works as expected on hard-coded test cases"
             (hardCodedTestCases
                 |> List.indexedMap
                     (\index ( string, codePoints ) ->
                         test ("toCodePoints works properly - test case " ++ Debug.toString index)
-                            (\() -> toCodePoints string |> Expect.equal codePoints)
+                            (\() -> String.Extra.toCodePoints string |> Expect.equal codePoints)
                     )
             )
         , describe "fromCodePoints works as expected on hard-coded test cases"
@@ -116,7 +116,7 @@ unicodeTests =
                 |> List.indexedMap
                     (\index ( string, codePoints ) ->
                         test ("fromCodePoints works properly - test case " ++ Debug.toString index)
-                            (\() -> fromCodePoints codePoints |> Expect.equal string)
+                            (\() -> String.Extra.fromCodePoints codePoints |> Expect.equal string)
                     )
             )
         ]


### PR DESCRIPTION
This does use `suppress` for non tail called based recursion, however given that tail calls may well decrease performance for some loads and blowing the stack may be fairly unlikely, it's not necessarily something I want to fix totally casually.

Otherwise, most of the fixes were me pressing copy paste very rapidly... :(

