### PR TITLE
Improve performance of String.Extra.isBlank

### DIFF
--- a/benchmarks/elm.json
+++ b/benchmarks/elm.json
@@ -10,6 +10,7 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
+            "elm/regex": "1.0.0",
             "elm-explorations/benchmark": "1.0.2",
             "lue-bird/elm-alternative-benchmark-runner": "1.0.0"
         },
@@ -17,7 +18,6 @@
             "BrianHicks/elm-trend": "2.1.3",
             "avh4/elm-color": "1.0.0",
             "elm/json": "1.1.3",
-            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.3",

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -20,6 +20,7 @@ import Benchmark.Runner.Alternative as BenchmarkRunner
 import List.Extra
 import List.Extra.Unfoldr
 import List.Extra.UniquePairs
+import String.Extra.IsBlank
 
 
 main : BenchmarkRunner.Program
@@ -30,6 +31,7 @@ main =
         , arrayExtra
         , listExtra
         , tupleExtra
+        , stringExtra
         ]
         |> BenchmarkRunner.program
 
@@ -193,6 +195,40 @@ tupleExtra : Benchmark
 tupleExtra =
     describe "Tuple.Extra"
         [ Benchmark.compare "construction" "literal" (\() -> ( 1, "a" )) "function" (\() -> Tuple.pair 1 "a")
+        ]
+
+
+stringExtra : Benchmark
+stringExtra =
+    describe "String.Extra"
+        [ stringExtraIsBlank
+        ]
+
+
+stringExtraIsBlank : Benchmark
+stringExtraIsBlank =
+    let
+        bench label string =
+            rank label
+                (\isBlank -> isBlank string)
+                [ ( "regex based", String.Extra.IsBlank.regexBased )
+                , ( "regex based (with top-level regex)", String.Extra.IsBlank.regexBasedWithTopLevelRegex )
+                , ( "trim based", String.Extra.IsBlank.trimBased )
+                ]
+
+        emptyString =
+            ""
+
+        wsString =
+            String.repeat 10 " "
+
+        fullString =
+            String.repeat 10 "Hello World"
+    in
+    Benchmark.describe "isBlank"
+        [ bench "empty string" emptyString
+        , bench "whitespace string" wsString
+        , bench "full string" fullString
         ]
 
 

--- a/benchmarks/src/String/Extra/IsBlank.elm
+++ b/benchmarks/src/String/Extra/IsBlank.elm
@@ -1,0 +1,28 @@
+module String.Extra.IsBlank exposing (regexBased, regexBasedWithTopLevelRegex, trimBased)
+
+import Regex exposing (Regex)
+
+
+regexFromString : String -> Regex
+regexFromString =
+    Regex.fromString >> Maybe.withDefault Regex.never
+
+
+regexBased : String -> Bool
+regexBased string =
+    Regex.contains (regexFromString "^\\s*$") string
+
+
+isBlankRegex : Regex
+isBlankRegex =
+    regexFromString "^\\s*$"
+
+
+regexBasedWithTopLevelRegex : String -> Bool
+regexBasedWithTopLevelRegex string =
+    Regex.contains isBlankRegex string
+
+
+trimBased : String -> Bool
+trimBased string =
+    String.trim string == ""

--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -213,13 +213,13 @@ clean string =
 
 {-| Test if a string is empty or only contains whitespace.
 
-    isBlank "" == True
+    isBlank "" --> True
 
-    isBlank "\n" == True
+    isBlank "\n" --> True
 
-    isBlank "  " == True
+    isBlank "  " --> True
 
-    isBlank " a" == False
+    isBlank " a" --> False
 
 -}
 isBlank : String -> Bool

--- a/src/String/Extra.elm
+++ b/src/String/Extra.elm
@@ -224,7 +224,7 @@ clean string =
 -}
 isBlank : String -> Bool
 isBlank string =
-    Regex.contains (regexFromString "^\\s*$") string
+    String.trim string == ""
 
 
 {-| Convert an underscored or dasherized string to a camelized one.

--- a/tests/String/Tests.elm
+++ b/tests/String/Tests.elm
@@ -216,6 +216,37 @@ isBlankTest =
                 String.Extra.isBlank " Slartibartfast"
                     |> Expect.equal False
                     |> Expect.onFail "Did not return false"
+        , fuzz whitespaceHeavyStringFuzzer "Oracle test: ensure no behaviour change between implementations" <|
+            let
+                regexFromString =
+                    Regex.fromString >> Maybe.withDefault Regex.never
+
+                trimBased str =
+                    String.trim str == ""
+
+                regexBased str =
+                    Regex.contains (regexFromString "^\\s*$") str
+            in
+            \str ->
+                trimBased str
+                    |> Expect.equal (regexBased str)
+        ]
+
+
+whitespaceHeavyStringFuzzer : Fuzzer String
+whitespaceHeavyStringFuzzer =
+    Fuzz.list whitespaceHeavyCharFuzzer
+        |> Fuzz.map String.fromList
+
+
+whitespaceHeavyCharFuzzer : Fuzzer Char
+whitespaceHeavyCharFuzzer =
+    Fuzz.frequency
+        [ ( 3, Fuzz.constant ' ' )
+        , ( 3, Fuzz.constant '\n' )
+        , ( 3, Fuzz.constant '\t' )
+        , ( 3, Fuzz.constant '\u{000D}' ) -- \r
+        , ( 1, Fuzz.char )
         ]
 
 


### PR DESCRIPTION
This changes the implementation of String.Extra.isBlank from a regex-based one to a `String.trim`-using one.

This benchmark shows improvement, at least in my Chrome:
```elm
suite : Benchmark
suite =
    let
        emptyString =
            ""

        wsString =
            String.repeat 10 " "

        fullString =
            String.repeat 10 "Hello World"
    in
    Benchmark.describe "String.isBlank"
        [ Benchmark.compare "Empty string"
            "String.Extra"
            (\_ -> fn1 emptyString)
            "naive"
            (\_ -> fn2 emptyString)
        , Benchmark.compare "Whitespace string"
            "String.Extra"
            (\_ -> fn1 wsString)
            "naive"
            (\_ -> fn2 wsString)
        , Benchmark.compare "Full string"
            "String.Extra"
            (\_ -> fn1 fullString)
            "naive"
            (\_ -> fn2 fullString)
        ]


fn1 string =
    --Regex.contains (regexFromString "^\\s*$") string
    String.Extra.isBlank string


fn2 string =
    String.trim string == ""
```

![Results](https://github.com/gampleman/core-extra/assets/149425/be771606-739c-40a5-8aea-e265fb530dbf)

Results show between 5x and 10x speed increase.

This test passes, comparing the output of the two functions:
```elm
suite : Test
suite =
    Test.fuzz wsHeavyStringFuzzer "Oracle test for new impl of String.Extra.isBlank" <|
        \str ->
            (String.trim str == "")
                |> Expect.equal (String.Extra.isBlank str)


wsHeavyStringFuzzer : Fuzzer String
wsHeavyStringFuzzer =
    Fuzz.list wsHeavyCharFuzzer
        |> Fuzz.map String.fromList


wsHeavyCharFuzzer : Fuzzer Char
wsHeavyCharFuzzer =
    Fuzz.frequency
        [ ( 3, Fuzz.constant ' ' )
        , ( 3, Fuzz.constant '\n' )
        , ( 3, Fuzz.constant '\t' )
        , ( 3, Fuzz.constant '\u{000D}' ) -- \r
        , ( 1, Fuzz.char )
        ]
```