### PR TITLE
add Array.Extra.singleton

### DIFF
--- a/benchmarks/src/Array/Extra/Singleton.elm
+++ b/benchmarks/src/Array/Extra/Singleton.elm
@@ -1,4 +1,4 @@
-module Array.Extra.Singleton exposing (repeat1, initialize1, pushEmpty, fromList, mapExistingSingleton)
+module Array.Extra.Singleton exposing (fromList, initialize1, mapExistingSingleton, pushEmpty, repeat1)
 
 import Array exposing (Array)
 
@@ -10,7 +10,7 @@ repeat1 element =
 
 initialize1 : a -> Array a
 initialize1 element =
-    Array.initialize 1 (\_-> element)
+    Array.initialize 1 (\_ -> element)
 
 
 pushEmpty : a -> Array a

--- a/benchmarks/src/Array/Extra/Singleton.elm
+++ b/benchmarks/src/Array/Extra/Singleton.elm
@@ -1,0 +1,33 @@
+module Array.Extra.Singleton exposing (repeat1, initialize1, pushEmpty, fromList, mapExistingSingleton)
+
+import Array exposing (Array)
+
+
+repeat1 : a -> Array a
+repeat1 element =
+    Array.repeat 1 element
+
+
+initialize1 : a -> Array a
+initialize1 element =
+    Array.initialize 1 (\_-> element)
+
+
+pushEmpty : a -> Array a
+pushEmpty element =
+    Array.push element Array.empty
+
+
+fromList : a -> Array a
+fromList element =
+    Array.fromList [ element ]
+
+
+mapExistingSingleton : a -> Array a
+mapExistingSingleton element =
+    Array.map (\() -> element) existingSingleton
+
+
+existingSingleton : Array ()
+existingSingleton =
+    Array.push () Array.empty

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -3,6 +3,7 @@ module Benchmarks exposing (main)
 import Application.NegAbs
 import Application.Sum
 import Array exposing (Array)
+import Array.Extra.Singleton
 import Array.Extra as Array
 import Array.Extra.All
 import Array.Extra.Any
@@ -182,6 +183,17 @@ arrayExtra =
             , ( "recursive", Array.Extra.Member.recursive )
             , ( "with List.member", Array.Extra.Member.withList )
             , ( "with any", Array.Extra.Member.withAny )
+            ]
+        , let
+            element = ( 2, 3 )
+          in
+          rank "singleton"
+            (\singleton -> singleton element)
+            [ ( "initialize 1 (\\_ -> _)", Array.Extra.Singleton.initialize1 )
+            , ( "repeat 1 _", Array.Extra.Singleton.repeat1 )
+            , ( "fromList [ _ ]", Array.Extra.Singleton.fromList )
+            , ( "push _ empty", Array.Extra.Singleton.pushEmpty )
+            , ( "map (\\() -> element) existingSingleton", Array.Extra.Singleton.mapExistingSingleton )
             ]
         ]
 

--- a/benchmarks/src/Benchmarks.elm
+++ b/benchmarks/src/Benchmarks.elm
@@ -3,7 +3,6 @@ module Benchmarks exposing (main)
 import Application.NegAbs
 import Application.Sum
 import Array exposing (Array)
-import Array.Extra.Singleton
 import Array.Extra as Array
 import Array.Extra.All
 import Array.Extra.Any
@@ -14,6 +13,7 @@ import Array.Extra.Map2
 import Array.Extra.MapToList
 import Array.Extra.Member
 import Array.Extra.Reverse
+import Array.Extra.Singleton
 import Array.Extra.Unzip
 import Benchmark exposing (Benchmark, describe)
 import Benchmark.Alternative exposing (rank)
@@ -185,7 +185,8 @@ arrayExtra =
             , ( "with any", Array.Extra.Member.withAny )
             ]
         , let
-            element = ( 2, 3 )
+            element =
+                ( 2, 3 )
           in
           rank "singleton"
             (\singleton -> singleton element)

--- a/src/Array/Extra.elm
+++ b/src/Array/Extra.elm
@@ -1,5 +1,6 @@
 module Array.Extra exposing
-    ( all, any, member
+    ( singleton
+    , all, any, member
     , reverse, intersperse, update, pop, removeAt, insertAt
     , removeWhen, filterMap
     , sliceFrom, sliceUntil, splitAt, unzip, last
@@ -9,6 +10,11 @@ module Array.Extra exposing
     )
 
 {-| Convenience functions for working with `Array`
+
+
+# Creation
+
+@docs singleton
 
 
 # Predicates
@@ -48,6 +54,19 @@ module Array.Extra exposing
 -}
 
 import Array exposing (Array, append, empty, initialize, length, repeat, slice)
+
+
+{-| Create an array containing only the one given element:
+
+    import Array exposing (fromList, length)
+
+    singleton 1234 --> fromList [ 1234 ]
+    length (singleton "hi") --> 1
+
+-}
+singleton : a -> Array a
+singleton element =
+    Array.push element Array.empty
 
 
 {-| Update the element at a given index based on its current value.


### PR DESCRIPTION
Adds `Array.Extra.singleton e = Array.push e Array.empty`.
Thanks @lydell  for the benchmarks: https://github.com/jfmengels/elm-benchmarks/pull/2
Here's the numbers with --optimize
chromium:
<img width="770" height="194" alt="Screenshot From 2026-08-05 20-30-36" src="https://github.com/user-attachments/assets/cb30bc56-49fd-40df-857a-422db9747b0f" />
firefox:
<img width="770" height="194" alt="Screenshot From 2026-08-05 20-30-18" src="https://github.com/user-attachments/assets/a90b13b5-64c4-4382-b8ca-8098466883b1" />

`Arry.initialize` comes close but doesn't generally beat push into empty.